### PR TITLE
 fix: embed EPSG in Zarr attrs for TiTiler CRS detection

### DIFF
--- a/src/eopf_geozarr/tests/test_crs_metadata.py
+++ b/src/eopf_geozarr/tests/test_crs_metadata.py
@@ -1,0 +1,47 @@
+"""Tests for CRS metadata embedding in Zarr attributes."""
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from eopf_geozarr.conversion.geozarr import prepare_dataset_with_crs_info
+
+EPSG_32632 = 32632
+
+
+@pytest.fixture
+def utm_dataset():
+    """Minimal UTM dataset."""
+    return xr.Dataset(
+        {"data": (["y", "x"], np.random.rand(10000, 11000))},
+        coords={
+            "x": np.arange(0, 110000, 10, dtype=np.float64),
+            "y": np.arange(5300000, 5200000, -10, dtype=np.float64),
+        },
+    )
+
+
+@pytest.fixture
+def zarr_roundtrip(utm_dataset, tmp_path):
+    """Dataset after Zarr write/read."""
+    ds = prepare_dataset_with_crs_info(utm_dataset, reference_crs=f"EPSG:{EPSG_32632}")
+    path = tmp_path / "test.zarr"
+    ds.drop_encoding().to_zarr(path, mode="w", zarr_format=3, consolidated=True)
+    return xr.open_zarr(path, zarr_format=3, consolidated=True)
+
+
+def test_crs_attrs_embedded(utm_dataset):
+    """CRS metadata written to attrs."""
+    ds = prepare_dataset_with_crs_info(utm_dataset, reference_crs=f"EPSG:{EPSG_32632}")
+    assert ds.attrs["proj:epsg"] == EPSG_32632
+    assert ds.attrs["proj:code"] == f"EPSG:{EPSG_32632}"
+
+
+def test_crs_persists_through_zarr(zarr_roundtrip):
+    """CRS survives Zarr cycle."""
+    assert zarr_roundtrip.attrs["proj:epsg"] == EPSG_32632
+
+
+def test_rioxarray_reads_crs(zarr_roundtrip):
+    """rioxarray reads CRS."""
+    assert zarr_roundtrip.rio.crs.to_epsg() == EPSG_32632


### PR DESCRIPTION
TiTiler defaults to EPSG:4326 when `ds.rio.crs` returns None after Zarr I/O, causing validation errors on native UTM coordinates (e.g., treating 600000 meters as longitude degrees).

**Solution**
Embed proj:epsg and proj:code in dataset attrs so rioxarray reconstructs CRS after Zarr write/read cycle.

**Changes**

- Add _embed_crs_in_attrs() helper
- Call from `prepare_dataset_with_crs_info()`
- Add validation test test_crs_fix.py

**Impact**

- Fixes TiTiler 500 errors on UTM datasets
- Enables correct tile rendering in STAC browser