### PR TITLE
simplify type hints

### DIFF
--- a/src/eopf_geozarr/cli.py
+++ b/src/eopf_geozarr/cli.py
@@ -9,7 +9,7 @@ import argparse
 import sys
 import warnings
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import xarray as xr
 
@@ -29,7 +29,7 @@ warnings.filterwarnings("ignore", message=".*", category=UserWarning)
 warnings.filterwarnings("ignore", message=".*", category=RuntimeWarning)
 
 
-def setup_dask_cluster(enable_dask: bool, verbose: bool = False) -> Optional[Any]:
+def setup_dask_cluster(enable_dask: bool, verbose: bool = False) -> Any | None:
     """
     Set up a dask cluster for parallel processing.
 

--- a/src/eopf_geozarr/conversion/fs_utils.py
+++ b/src/eopf_geozarr/conversion/fs_utils.py
@@ -106,7 +106,7 @@ def get_s3_storage_options(s3_path: str, **s3_kwargs: Any) -> S3FsOptions:
 
     Returns
     -------
-    Dict[str, Any]
+    dict[str, Any]
         Storage options dictionary for xarray
     """
     # Set up default S3 configuration
@@ -147,7 +147,7 @@ def get_storage_options(path: str, **kwargs: Any) -> S3FsOptions | None:
 
     Returns
     -------
-    Optional[Dict[str, Any]]
+    dict[str, Any] | None
         Storage options dictionary for xarray/zarr, or None for local paths
     """
     if is_s3_path(path):
@@ -390,7 +390,7 @@ def validate_s3_access(s3_path: str, **s3_kwargs: Any) -> tuple[bool, str | None
 
     Returns
     -------
-    tuple[bool, Optional[str]]
+    tuple[bool, str | None]
         Tuple of (success, error_message)
     """
     try:

--- a/src/eopf_geozarr/conversion/geozarr.py
+++ b/src/eopf_geozarr/conversion/geozarr.py
@@ -19,7 +19,7 @@ import os
 import shutil
 import time
 from collections.abc import Hashable, Iterable, Mapping, Sequence
-from typing import Any, Dict, Tuple
+from typing import Any
 
 import numpy as np
 import xarray as xr
@@ -155,7 +155,7 @@ def create_geozarr_dataset(
 
 def setup_datatree_metadata_geozarr_spec_compliant(
     dt: xr.DataTree, groups: Iterable[str], gcp_group: str | None = None
-) -> Dict[str, xr.Dataset]:
+) -> dict[str, xr.Dataset]:
     """
     Set up GeoZarr-spec compliant CF standard names and CRS information.
 
@@ -529,7 +529,7 @@ def create_geozarr_compliant_multiscales(
     spatial_chunk: int = 4096,
     ds_gcp: xr.Dataset | None = None,
     enable_sharding: bool = False,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Create GeoZarr-spec compliant multiscales following the specification exactly.
 
@@ -897,7 +897,7 @@ def create_overview_dataset_all_vars(
     width: int,
     height: int,
     native_crs: Any,
-    native_bounds: Tuple[float, float, float, float],
+    native_bounds: tuple[float, float, float, float],
     data_vars: Sequence[Hashable],
     ds_gcp: xr.Dataset | None = None,
     enable_sharding: bool = False,

--- a/src/eopf_geozarr/conversion/sentinel1_reprojection.py
+++ b/src/eopf_geozarr/conversion/sentinel1_reprojection.py
@@ -5,8 +5,6 @@ This module provides functions to reproject Sentinel-1 GRD data from radar geome
 to geographic coordinates (lat/lon) using Ground Control Points (GCPs).
 """
 
-from typing import Optional, Tuple, Union
-
 import numpy as np
 import rasterio
 import rioxarray  # noqa: F401  # Import to enable .rio accessor
@@ -19,7 +17,7 @@ def reproject_sentinel1_with_gcps(
     ds_gcp: xr.Dataset,
     target_crs: str = "EPSG:4326",
     resampling: Resampling = Resampling.bilinear,
-    nodata_value: Optional[float] = None,
+    nodata_value: float | None = None,
 ) -> xr.Dataset:
     """
     Reproject Sentinel-1 dataset from radar geometry to geographic coordinates using GCPs.
@@ -177,7 +175,7 @@ def _create_target_coordinates(
     return coords
 
 
-def _determine_nodata_value(data_var: xr.DataArray) -> Union[float, np.floating]:
+def _determine_nodata_value(data_var: xr.DataArray) -> float | np.floating:
     """
     Determine appropriate nodata value based on data type and existing attributes.
 
@@ -334,7 +332,7 @@ def _reproject_2d_array(
 
 def calculate_reprojected_bounds(
     ds_gcp: xr.Dataset, target_crs: str = "EPSG:4326"
-) -> Tuple[float, float, float, float]:
+) -> tuple[float, float, float, float]:
     """
     Calculate bounds of reprojected data based on GCPs.
 

--- a/src/eopf_geozarr/conversion/utils.py
+++ b/src/eopf_geozarr/conversion/utils.py
@@ -1,7 +1,5 @@
 """Utility functions for GeoZarr conversion."""
 
-from typing import Optional
-
 import numpy as np
 import rasterio  # noqa: F401  # Import to enable .rio accessor
 import xarray as xr
@@ -11,7 +9,7 @@ def downsample_2d_array(
     source_data: np.ndarray,
     target_height: int,
     target_width: int,
-    nodata_value: Optional[float] = None,
+    nodata_value: float | None = None,
 ) -> np.ndarray:
     """
     Downsample a 2D array using block averaging with proper nodata handling.


### PR DESCRIPTION
- Use built-ins like `tuple`, `dict` instead of `typing.Tuple`, `typing.Dict`
- Use `A | None` instead of `Optional[A]`
- Use `A | B` instead of `Union[A, B]`