### PR TITLE
set up VCS versioning based on git tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,6 @@ tests-output/
 # uv
 uv.lock
 .vscode/settings.json
+
+# VCS versioning
+src/eopf_geozarr/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=61.0", "setuptools-scm>=8.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "eopf-geozarr"
-version = "0.3.0"
+dynamic = ["version"]
 description = "GeoZarr compliant data model for EOPF datasets"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -55,6 +55,7 @@ dev = [
     "pre-commit>=3.0.0",
     "bandit[toml]>=1.7.0",
     "safety>=2.0.0",
+    "setuptools-scm>=9.2.2",
 ]
 test = [
     "jsondiff>=2.2.1",
@@ -80,6 +81,9 @@ Documentation = "https://github.com/developmentseed/eopf-geozarr/tree/main/docs"
 
 [project.scripts]
 eopf-geozarr = "eopf_geozarr.cli:main"
+
+[tool.setuptools_scm]
+version_file = "src/eopf_geozarr/_version.py"
 
 [tool.setuptools.packages.find]
 where = ["src"]
@@ -178,3 +182,5 @@ skips = ["B101", "B601"]
 
 [tool.uv]
 default-groups = ["dev", "test"]
+
+


### PR DESCRIPTION
replaces explicit package versioning with dynamic versioning based on git tags. closes #87 