### PR TITLE
fix: typo to prevent crash in quality-mask downsampling

### DIFF
--- a/src/eopf_geozarr/s2_optimization/s2_multiscale.py
+++ b/src/eopf_geozarr/s2_optimization/s2_multiscale.py
@@ -598,9 +598,7 @@ def create_downsampled_resolution_group(source_dataset: xr.Dataset, factor: int)
             continue
         var_typ = determine_variable_type(var_name, var_data)
         if var_typ == "quality_mask":
-            lazy_downsampled = (
-                var_data.coarsen({"x": factor, "y": factor}, boundary="trim").max().sdyupr
-            )
+            lazy_downsampled = var_data.coarsen({"x": factor, "y": factor}, boundary="trim").max()
         elif var_typ == "reflectance":
             lazy_downsampled = var_data.coarsen({"x": factor, "y": factor}, boundary="trim").mean()
         elif var_typ == "classification":

--- a/tests/test_s2_multiscale.py
+++ b/tests/test_s2_multiscale.py
@@ -14,6 +14,7 @@ from structlog.testing import capture_logs
 from eopf_geozarr.s2_optimization.s2_multiscale import (
     calculate_aligned_chunk_size,
     calculate_simple_shard_dimensions,
+    create_downsampled_resolution_group,
     create_measurements_encoding,
     create_multiscale_from_datatree,
 )
@@ -53,6 +54,24 @@ def sample_dataset() -> xr.Dataset:
 
 class TestS2MultiscaleFunctions:
     """Test suite for S2 multiscale functions."""
+
+    def test_create_downsampled_resolution_group_quality_mask(self) -> None:
+        """Quality-mask downsampling should not crash and should preserve dtype."""
+        x = np.arange(8)
+        y = np.arange(6)
+        quality = xr.DataArray(
+            np.random.randint(0, 2, (6, 8), dtype=np.uint8),
+            dims=["y", "x"],
+            coords={"y": y, "x": x},
+            name="quality_clouds",
+        )
+        ds = xr.Dataset({"quality_clouds": quality})
+
+        out = create_downsampled_resolution_group(ds, factor=2)
+
+        assert "quality_clouds" in out.data_vars
+        assert out["quality_clouds"].dtype == np.uint8
+        assert out["quality_clouds"].shape == (3, 4)
 
     def test_calculate_simple_shard_dimensions(self) -> None:
         """Test simplified shard dimensions calculation."""


### PR DESCRIPTION
Removes `.sdyupr` after `.max()` in `create_downsampled_resolution_group()`. Likely just a typo introduced by [260a99a](https://github.com/EOPF-Explorer/data-model/blame/260a99ad7be463f04745388090c3319c3e9de589/src/eopf_geozarr/s2_optimization/s2_multiscale.py#L616). 
This will cause a runtime crash when downsampling quality-mask variables during S2 optimized multiscale generation.

Added a test to prevent this: `uv run pytest -q tests/test_s2_multiscale.py::TestS2MultiscaleFunctions::test_create_downsampled_resolution_group_quality_mask`.