### PR TITLE
feat: Phase 3 — S1Tiling conditions ingestion and discovery

### DIFF
--- a/src/eopf_geozarr/cli.py
+++ b/src/eopf_geozarr/cli.py
@@ -1210,7 +1210,10 @@ def add_s1_ingestion_commands(subparsers: argparse._SubParsersAction) -> None:
     # ingest-s1-conditions: condition arrays
     cond_parser = subparsers.add_parser(
         "ingest-s1-conditions",
-        help="Ingest S1Tiling condition arrays (gamma_area, LIA) into a GeoZarr V3 store",
+        help=(
+            "Ingest S1Tiling condition arrays "
+            "(gamma_area, LIA, incidence_angle) into a GeoZarr V3 store"
+        ),
     )
     cond_parser.add_argument(
         "--store", type=str, required=True, help="Path to existing Zarr V3 store"

--- a/src/eopf_geozarr/cli.py
+++ b/src/eopf_geozarr/cli.py
@@ -1020,6 +1020,60 @@ def validate_command(args: argparse.Namespace) -> None:
         sys.exit(1)
 
 
+# =============================================================================
+# S1 Ingestion Commands
+# =============================================================================
+
+
+def ingest_s1_command(args: argparse.Namespace) -> None:
+    """Ingest a single S1Tiling acquisition into a GeoZarr V3 store."""
+    from .conversion.s1_ingest import ingest_s1tiling_acquisition
+
+    try:
+        idx = ingest_s1tiling_acquisition(
+            vv_path=args.vv,
+            vh_path=args.vh,
+            border_mask_path=args.mask,
+            store_path=args.store,
+            orbit_direction=args.orbit_dir,
+        )
+        log.info("✅ Acquisition ingested", time_index=idx, store=args.store)
+    except Exception as e:
+        log.error("❌ Error ingesting acquisition", error=str(e))
+        sys.exit(1)
+
+
+def ingest_s1_conditions_command(args: argparse.Namespace) -> None:
+    """Ingest S1Tiling condition arrays into a GeoZarr V3 store."""
+    from .conversion.s1_ingest import ingest_s1tiling_conditions
+
+    try:
+        ingest_s1tiling_conditions(
+            store_path=args.store,
+            orbit_direction=args.orbit_dir,
+            relative_orbit=args.relative_orbit,
+            gamma_area_path=getattr(args, "gamma_area", None),
+            lia_path=getattr(args, "lia", None),
+            incidence_angle_path=getattr(args, "incidence_angle", None),
+        )
+        log.info("✅ Conditions ingested", store=args.store, orbit_dir=args.orbit_dir)
+    except Exception as e:
+        log.error("❌ Error ingesting conditions", error=str(e))
+        sys.exit(1)
+
+
+def consolidate_s1_command(args: argparse.Namespace) -> None:
+    """Consolidate metadata for an S1 GeoZarr store."""
+    from .conversion.s1_ingest import consolidate_s1_store
+
+    try:
+        consolidate_s1_store(args.store, args.orbit_dir)
+        log.info("✅ Metadata consolidated", store=args.store)
+    except Exception as e:
+        log.error("❌ Error consolidating metadata", error=str(e))
+        sys.exit(1)
+
+
 def create_parser() -> argparse.ArgumentParser:
     """
     Create the argument parser for the CLI.
@@ -1127,7 +1181,72 @@ def create_parser() -> argparse.ArgumentParser:
     # Add S2 optimization commands
     add_s2_optimization_commands(subparsers)
 
+    # Add S1 ingestion commands
+    add_s1_ingestion_commands(subparsers)
+
     return parser
+
+
+def add_s1_ingestion_commands(subparsers: argparse._SubParsersAction) -> None:
+    """Add S1 GRD RTC ingestion commands to CLI parser."""
+
+    # ingest-s1: single acquisition
+    s1_parser = subparsers.add_parser(
+        "ingest-s1", help="Ingest a single S1Tiling acquisition into a GeoZarr V3 store"
+    )
+    s1_parser.add_argument("--vv", type=str, required=True, help="Path to VV GeoTIFF")
+    s1_parser.add_argument("--vh", type=str, required=True, help="Path to VH GeoTIFF")
+    s1_parser.add_argument("--mask", type=str, required=True, help="Path to border mask GeoTIFF")
+    s1_parser.add_argument("--store", type=str, required=True, help="Path to output Zarr V3 store")
+    s1_parser.add_argument(
+        "--orbit-dir",
+        type=str,
+        required=True,
+        choices=["ascending", "descending"],
+        help="Orbit direction",
+    )
+    s1_parser.set_defaults(func=ingest_s1_command)
+
+    # ingest-s1-conditions: condition arrays
+    cond_parser = subparsers.add_parser(
+        "ingest-s1-conditions",
+        help="Ingest S1Tiling condition arrays (gamma_area, LIA) into a GeoZarr V3 store",
+    )
+    cond_parser.add_argument(
+        "--store", type=str, required=True, help="Path to existing Zarr V3 store"
+    )
+    cond_parser.add_argument(
+        "--orbit-dir",
+        type=str,
+        required=True,
+        choices=["ascending", "descending"],
+        help="Orbit direction",
+    )
+    cond_parser.add_argument(
+        "--relative-orbit", type=int, required=True, help="Relative orbit number (e.g. 37)"
+    )
+    cond_parser.add_argument(
+        "--gamma-area", type=str, default=None, help="Path to gamma area GeoTIFF"
+    )
+    cond_parser.add_argument("--lia", type=str, default=None, help="Path to LIA GeoTIFF")
+    cond_parser.add_argument(
+        "--incidence-angle", type=str, default=None, help="Path to incidence angle GeoTIFF"
+    )
+    cond_parser.set_defaults(func=ingest_s1_conditions_command)
+
+    # consolidate-s1: metadata consolidation
+    cons_parser = subparsers.add_parser(
+        "consolidate-s1", help="Consolidate metadata for an S1 GeoZarr V3 store"
+    )
+    cons_parser.add_argument("--store", type=str, required=True, help="Path to Zarr V3 store")
+    cons_parser.add_argument(
+        "--orbit-dir",
+        type=str,
+        required=True,
+        choices=["ascending", "descending"],
+        help="Orbit direction",
+    )
+    cons_parser.set_defaults(func=consolidate_s1_command)
 
 
 def add_s2_optimization_commands(subparsers: argparse._SubParsersAction) -> None:

--- a/src/eopf_geozarr/conversion/__init__.py
+++ b/src/eopf_geozarr/conversion/__init__.py
@@ -20,8 +20,10 @@ from .geozarr import (
 from .s1_ingest import (
     consolidate_s1_store,
     discover_s1tiling_acquisitions,
+    discover_s1tiling_conditions,
     extract_geotiff_metadata,
     ingest_s1tiling_acquisition,
+    ingest_s1tiling_conditions,
 )
 from .utils import (
     calculate_aligned_chunk_size,
@@ -40,10 +42,12 @@ __all__ = [
     "consolidate_s1_store",
     "create_geozarr_dataset",
     "discover_s1tiling_acquisitions",
+    "discover_s1tiling_conditions",
     "downsample_2d_array",
     "extract_geotiff_metadata",
     "get_s3_credentials_info",
     "ingest_s1tiling_acquisition",
+    "ingest_s1tiling_conditions",
     "is_grid_mapping_variable",
     "is_s3_path",
     "iterative_copy",

--- a/src/eopf_geozarr/conversion/s1_ingest.py
+++ b/src/eopf_geozarr/conversion/s1_ingest.py
@@ -69,9 +69,9 @@ S1TILING_FILENAME_PATTERN = re.compile(
 )
 
 # S1Tiling conditions filename patterns
-# e.g. GAMMA_AREA_31TCH_008.tif or GAMMA_AREA_s1a_31TCH_ASC_008.tif
+# e.g. GAMMA_AREA_31TCH_008.tif (tile-independent of orbit direction)
 S1TILING_GAMMA_AREA_PATTERN = re.compile(
-    r"^GAMMA_AREA_(?:s1[abc]_)?(?P<tile>[A-Z0-9]+)_(?:(?:ASC|DES)_)?(?P<orbit>\d{3})\.tif$",
+    r"^GAMMA_AREA_(?P<tile>[A-Z0-9]+)_(?P<orbit>\d{3})\.tif$",
     re.IGNORECASE,
 )
 # e.g. sin_LIA_31TCH_008.tif or LIA_31TCH_008.tif
@@ -785,11 +785,29 @@ def ingest_s1tiling_conditions(
         ref_shape = [src.height, src.width]
 
     # Validate CRS consistency with orbit group
-    store_crs = dict(orbit.attrs).get("proj:code")
+    orbit_attrs = dict(orbit.attrs)
+    store_crs = orbit_attrs.get("proj:code")
     if store_crs and store_crs != ref_crs:
         raise ValueError(
             f"CRS mismatch: store has {store_crs}, condition GeoTIFF has {ref_crs}"
         )
+
+    # Validate transform/shape against orbit group's native grid
+    store_layout = orbit_attrs.get("multiscales", {}).get("layout", [])
+    if store_layout:
+        native_entry = store_layout[0]
+        store_transform = native_entry.get("spatial:transform")
+        if store_transform and store_transform != ref_transform:
+            raise ValueError(
+                f"Transform mismatch: orbit group native grid has {store_transform}, "
+                f"condition GeoTIFF has {ref_transform}"
+            )
+        store_shape = native_entry.get("spatial:shape")
+        if store_shape and store_shape != ref_shape:
+            raise ValueError(
+                f"Shape mismatch: orbit group native grid has {store_shape}, "
+                f"condition GeoTIFF has {ref_shape}"
+            )
 
     # Create or open conditions group
     if "conditions" not in orbit:
@@ -867,12 +885,19 @@ def ingest_s1tiling_conditions(
                 dimension_names=["y", "x"],
             )
             arr[:, :] = data
+            finite_mask = np.isfinite(data)
+            if np.any(finite_mask):
+                min_val = float(np.nanmin(data[finite_mask]))
+                max_val = float(np.nanmax(data[finite_mask]))
+            else:
+                min_val = None
+                max_val = None
             log.info(
                 "Wrote condition array",
                 array_name=array_name,
                 shape=list(data.shape),
-                min=float(np.nanmin(data)),
-                max=float(np.nanmax(data)),
+                min=min_val,
+                max=max_val,
             )
 
     log.info(
@@ -906,17 +931,23 @@ def discover_s1tiling_conditions(input_dir: str | Path) -> list[dict]:
     for f in files:
         m = S1TILING_GAMMA_AREA_PATTERN.match(f.name)
         if m:
-            tile = m.group("tile")
+            tile = m.group("tile").upper()
             orbit = m.group("orbit")
             key = (tile, orbit)
             if key not in groups:
                 groups[key] = {"tile": tile, "orbit": orbit}
+            if "gamma_area" in groups[key]:
+                log.warning(
+                    "Duplicate gamma_area for same tile/orbit, overwriting",
+                    tile=tile, orbit=orbit, old=str(groups[key]["gamma_area"]),
+                    new=str(f),
+                )
             groups[key]["gamma_area"] = f
             continue
 
         m = S1TILING_LIA_PATTERN.match(f.name)
         if m:
-            tile = m.group("tile")
+            tile = m.group("tile").upper()
             orbit = m.group("orbit")
             key = (tile, orbit)
             if key not in groups:
@@ -926,7 +957,7 @@ def discover_s1tiling_conditions(input_dir: str | Path) -> list[dict]:
 
         m = S1TILING_INCIDENCE_ANGLE_PATTERN.match(f.name)
         if m:
-            tile = m.group("tile")
+            tile = m.group("tile").upper()
             orbit = m.group("orbit")
             key = (tile, orbit)
             if key not in groups:

--- a/src/eopf_geozarr/conversion/s1_ingest.py
+++ b/src/eopf_geozarr/conversion/s1_ingest.py
@@ -7,8 +7,10 @@ convention metadata.
 Public API:
     - extract_geotiff_metadata(path) -> S1TilingMetadata
     - ingest_s1tiling_acquisition(vv_path, vh_path, border_mask_path, store_path, orbit_direction) -> int
+    - ingest_s1tiling_conditions(store_path, orbit_direction, relative_orbit, ...) -> None
     - consolidate_s1_store(store_path, orbit_direction) -> None
     - discover_s1tiling_acquisitions(input_dir) -> list[dict]
+    - discover_s1tiling_conditions(input_dir) -> list[dict]
 """
 
 from __future__ import annotations
@@ -64,6 +66,18 @@ S1TILING_FILENAME_PATTERN = re.compile(
     r"(?P<acq_stamp>\d{8}t\d{6})_"
     r"(?P<product>GammaNaughtRTC)"
     r"(?P<mask>_BorderMask)?\.tif$"
+)
+
+# S1Tiling conditions filename patterns
+# e.g. GAMMA_AREA_31TCH_008.tif or GAMMA_AREA_s1a_31TCH_ASC_008.tif
+S1TILING_GAMMA_AREA_PATTERN = re.compile(
+    r"^GAMMA_AREA_(?:s1[abc]_)?(?P<tile>[A-Z0-9]+)_(?:(?:ASC|DES)_)?(?P<orbit>\d{3})\.tif$",
+    re.IGNORECASE,
+)
+# e.g. sin_LIA_31TCH_008.tif or LIA_31TCH_008.tif
+S1TILING_LIA_PATTERN = re.compile(
+    r"^(?P<kind>sin_LIA|LIA)_(?P<tile>[A-Z0-9]+)_(?P<orbit>\d{3})\.tif$",
+    re.IGNORECASE,
 )
 
 
@@ -685,3 +699,188 @@ def discover_s1tiling_acquisitions(input_dir: str | Path) -> list[dict]:
 
     log.info("Discovered acquisitions", count=len(acquisitions), input_dir=str(input_dir))
     return acquisitions
+
+
+# =============================================================================
+# Conditions Ingestion
+# =============================================================================
+
+
+def ingest_s1tiling_conditions(
+    store_path: str | Path,
+    orbit_direction: str,
+    relative_orbit: int,
+    gamma_area_path: str | Path | None = None,
+    lia_path: str | Path | None = None,
+    incidence_angle_path: str | Path | None = None,
+) -> None:
+    """Write time-invariant condition arrays into the conditions group.
+
+    Conditions are per-orbit (not per-acquisition) and have shape (Y, X) only.
+    The conditions group carries its own proj: and spatial: conventions.
+
+    Parameters
+    ----------
+    store_path : str or Path
+        Path to an existing Zarr V3 store (must already have the orbit group).
+    orbit_direction : str
+        Orbit direction group name (e.g. "ascending", "descending").
+    relative_orbit : int
+        Relative orbit number, used to suffix array names (e.g. 8 → "gamma_area_008").
+    gamma_area_path : str, Path, or None
+        Path to gamma area GeoTIFF. At least one condition path must be provided.
+    lia_path : str, Path, or None
+        Path to LIA (sin(LIA)) GeoTIFF.
+    incidence_angle_path : str, Path, or None
+        Path to incidence angle GeoTIFF.
+
+    Raises
+    ------
+    ValueError
+        If no condition paths are provided, or the store/orbit group doesn't exist.
+    FileNotFoundError
+        If any provided condition path does not exist.
+    """
+    condition_inputs: list[tuple[str, Path]] = []
+    for label, path in [
+        ("gamma_area", gamma_area_path),
+        ("lia", lia_path),
+        ("incidence_angle", incidence_angle_path),
+    ]:
+        if path is not None:
+            p = Path(path)
+            if not p.exists():
+                raise FileNotFoundError(f"Condition GeoTIFF not found: {p}")
+            condition_inputs.append((label, p))
+
+    if not condition_inputs:
+        raise ValueError("At least one condition path must be provided")
+
+    store_path = Path(store_path)
+    if not store_path.exists():
+        raise ValueError(f"Store does not exist: {store_path}")
+
+    orbit_suffix = f"{relative_orbit:03d}"
+
+    root = zarr.open_group(str(store_path), mode="r+", zarr_format=3)
+    if orbit_direction not in root:
+        raise ValueError(
+            f"Orbit direction '{orbit_direction}' not found in store. "
+            "Ingest at least one acquisition first."
+        )
+
+    orbit = root[orbit_direction]
+
+    # Read reference metadata from the first condition file
+    ref_label, ref_path = condition_inputs[0]
+    with rasterio.open(str(ref_path)) as src:
+        ref_crs = str(src.crs)
+        t = src.transform
+        ref_transform = [t.a, t.b, t.c, t.d, t.e, t.f]
+        ref_shape = [src.height, src.width]
+
+    # Validate CRS consistency with orbit group
+    store_crs = dict(orbit.attrs).get("proj:code")
+    if store_crs and store_crs != ref_crs:
+        raise ValueError(
+            f"CRS mismatch: store has {store_crs}, condition GeoTIFF has {ref_crs}"
+        )
+
+    # Create or open conditions group
+    if "conditions" not in orbit:
+        conditions = orbit.create_group("conditions")
+        conditions.attrs.update(
+            {
+                "proj:code": ref_crs,
+                "spatial:dimensions": ["y", "x"],
+                "spatial:transform": ref_transform,
+                "spatial:shape": ref_shape,
+            }
+        )
+        log.info("Created conditions group", orbit_direction=orbit_direction)
+    else:
+        conditions = orbit["conditions"]
+
+    # Write each condition array
+    for label, cond_path in condition_inputs:
+        array_name = f"{label}_{orbit_suffix}"
+
+        with rasterio.open(str(cond_path)) as src:
+            data = src.read(1).astype(np.float32)
+
+        h, w = data.shape
+
+        if array_name in conditions:
+            # Overwrite existing array
+            conditions[array_name][:, :] = data
+            log.info("Overwrote condition array", array_name=array_name)
+        else:
+            arr = conditions.create_array(
+                array_name,
+                shape=(h, w),
+                dtype="float32",
+                chunks=(
+                    calculate_aligned_chunk_size(h, 512),
+                    calculate_aligned_chunk_size(w, 512),
+                ),
+                compressors=zarr.codecs.BloscCodec(cname="zstd", clevel=5),
+                fill_value=float("nan"),
+                dimension_names=["y", "x"],
+            )
+            arr[:, :] = data
+            log.info(
+                "Wrote condition array",
+                array_name=array_name,
+                shape=list(data.shape),
+                min=float(np.nanmin(data)),
+                max=float(np.nanmax(data)),
+            )
+
+    log.info(
+        "Conditions ingestion complete",
+        orbit_direction=orbit_direction,
+        relative_orbit=orbit_suffix,
+        arrays=[f"{label}_{orbit_suffix}" for label, _ in condition_inputs],
+    )
+
+
+# =============================================================================
+# Conditions File Discovery
+# =============================================================================
+
+
+def discover_s1tiling_conditions(input_dir: str | Path) -> list[dict]:
+    """Discover S1Tiling condition GeoTIFF files (gamma_area, LIA).
+
+    Returns a list of dicts, each with keys:
+        tile, orbit, gamma_area (Path), lia (Path or None)
+
+    Groups by (tile, orbit).
+    """
+    input_dir = Path(input_dir)
+    files = sorted(input_dir.glob("*.tif"))
+    groups: dict[tuple[str, str], dict] = {}
+
+    for f in files:
+        m = S1TILING_GAMMA_AREA_PATTERN.match(f.name)
+        if m:
+            tile = m.group("tile")
+            orbit = m.group("orbit")
+            key = (tile, orbit)
+            if key not in groups:
+                groups[key] = {"tile": tile, "orbit": orbit}
+            groups[key]["gamma_area"] = f
+            continue
+
+        m = S1TILING_LIA_PATTERN.match(f.name)
+        if m:
+            tile = m.group("tile")
+            orbit = m.group("orbit")
+            key = (tile, orbit)
+            if key not in groups:
+                groups[key] = {"tile": tile, "orbit": orbit}
+            groups[key]["lia"] = f
+
+    conditions = list(groups.values())
+    log.info("Discovered conditions", count=len(conditions), input_dir=str(input_dir))
+    return conditions

--- a/src/eopf_geozarr/conversion/s1_ingest.py
+++ b/src/eopf_geozarr/conversion/s1_ingest.py
@@ -79,6 +79,11 @@ S1TILING_LIA_PATTERN = re.compile(
     r"^(?P<kind>sin_LIA|LIA)_(?P<tile>[A-Z0-9]+)_(?P<orbit>\d{3})\.tif$",
     re.IGNORECASE,
 )
+# e.g. incidence_angle_31TCH_008.tif
+S1TILING_INCIDENCE_ANGLE_PATTERN = re.compile(
+    r"^incidence_angle_(?P<tile>[A-Z0-9]+)_(?P<orbit>\d{3})\.tif$",
+    re.IGNORECASE,
+)
 
 
 # =============================================================================
@@ -800,19 +805,53 @@ def ingest_s1tiling_conditions(
         log.info("Created conditions group", orbit_direction=orbit_direction)
     else:
         conditions = orbit["conditions"]
+        # Validate existing conditions metadata matches the reference
+        cond_attrs = dict(conditions.attrs)
+        cond_crs = cond_attrs.get("proj:code")
+        if cond_crs is not None and cond_crs != ref_crs:
+            raise ValueError(
+                f"CRS mismatch: existing conditions group has {cond_crs}, "
+                f"reference condition GeoTIFF has {ref_crs}"
+            )
 
     # Write each condition array
     for label, cond_path in condition_inputs:
         array_name = f"{label}_{orbit_suffix}"
 
         with rasterio.open(str(cond_path)) as src:
+            cond_crs = str(src.crs)
+            t = src.transform
+            cond_transform = [t.a, t.b, t.c, t.d, t.e, t.f]
+            cond_shape = [src.height, src.width]
             data = src.read(1).astype(np.float32)
+
+        # Validate each condition file against the reference grid
+        if cond_crs != ref_crs:
+            raise ValueError(
+                f"CRS mismatch for condition '{label}' at '{cond_path}': "
+                f"expected {ref_crs}, got {cond_crs}"
+            )
+        if cond_transform != ref_transform:
+            raise ValueError(
+                f"Transform mismatch for condition '{label}' at '{cond_path}': "
+                f"expected {ref_transform}, got {cond_transform}"
+            )
+        if cond_shape != ref_shape:
+            raise ValueError(
+                f"Shape mismatch for condition '{label}' at '{cond_path}': "
+                f"expected {ref_shape}, got {cond_shape}"
+            )
 
         h, w = data.shape
 
         if array_name in conditions:
-            # Overwrite existing array
-            conditions[array_name][:, :] = data
+            existing = conditions[array_name]
+            if existing.shape != data.shape:
+                raise ValueError(
+                    f"Shape mismatch for condition array '{array_name}': "
+                    f"existing {existing.shape}, new {data.shape}"
+                )
+            existing[:, :] = data
             log.info("Overwrote condition array", array_name=array_name)
         else:
             arr = conditions.create_array(
@@ -850,10 +889,13 @@ def ingest_s1tiling_conditions(
 
 
 def discover_s1tiling_conditions(input_dir: str | Path) -> list[dict]:
-    """Discover S1Tiling condition GeoTIFF files (gamma_area, LIA).
+    """Discover S1Tiling condition GeoTIFF files (gamma_area, LIA, incidence_angle).
 
-    Returns a list of dicts, each with keys:
-        tile, orbit, gamma_area (Path), lia (Path or None)
+    Returns a list of dicts. Each dict always includes:
+        tile (str), orbit (str)
+    and may include any of:
+        gamma_area (Path), lia (Path), incidence_angle (Path)
+    depending on which files were discovered for that (tile, orbit).
 
     Groups by (tile, orbit).
     """
@@ -880,6 +922,16 @@ def discover_s1tiling_conditions(input_dir: str | Path) -> list[dict]:
             if key not in groups:
                 groups[key] = {"tile": tile, "orbit": orbit}
             groups[key]["lia"] = f
+            continue
+
+        m = S1TILING_INCIDENCE_ANGLE_PATTERN.match(f.name)
+        if m:
+            tile = m.group("tile")
+            orbit = m.group("orbit")
+            key = (tile, orbit)
+            if key not in groups:
+                groups[key] = {"tile": tile, "orbit": orbit}
+            groups[key]["incidence_angle"] = f
 
     conditions = list(groups.values())
     log.info("Discovered conditions", count=len(conditions), input_dir=str(input_dir))

--- a/tests/test_s1_rtc_ingest.py
+++ b/tests/test_s1_rtc_ingest.py
@@ -831,7 +831,7 @@ class TestIngestConditions:
     def test_overwrite_shape_mismatch_rejected(
         self, s1_store_with_acquisition: Path, tmp_path: Path
     ) -> None:
-        """Overwriting with a different shape raises ValueError."""
+        """Overwriting with a different shape/transform raises ValueError."""
         ga_path = tmp_path / "GAMMA_AREA_32TQM_037.tif"
 
         data_v1 = np.ones((SIZE, SIZE), dtype=np.float32)
@@ -843,7 +843,7 @@ class TestIngestConditions:
         data_v2 = np.ones((SIZE // 2, SIZE // 2), dtype=np.float32)
         transform = rasterio.transform.from_bounds(*BOUNDS, SIZE // 2, SIZE // 2)
         _create_synthetic_geotiff(ga_path, data_v2, transform=transform)
-        with pytest.raises(ValueError, match="Shape mismatch"):
+        with pytest.raises(ValueError, match="mismatch"):
             ingest_s1tiling_conditions(
                 s1_store_with_acquisition, "ascending", 37, gamma_area_path=ga_path
             )
@@ -885,7 +885,17 @@ class TestDiscoverConditions:
         assert "incidence_angle" in conditions[0]
         assert conditions[0]["tile"] == "32TQM"
         assert conditions[0]["orbit"] == "037"
+    def test_normalizes_tile_casing(self, tmp_path: Path) -> None:
+        """Tiles with different casing are grouped together."""
+        data = np.ones((SIZE, SIZE), dtype=np.float32)
+        _create_synthetic_geotiff(tmp_path / "GAMMA_AREA_32tqm_037.tif", data)
+        _create_synthetic_geotiff(tmp_path / "sin_LIA_32TQM_037.tif", data)
 
+        conditions = discover_s1tiling_conditions(tmp_path)
+        assert len(conditions) == 1
+        assert conditions[0]["tile"] == "32TQM"
+        assert "gamma_area" in conditions[0]
+        assert "lia" in conditions[0]
     def test_groups_gamma_area_and_lia(self, tmp_path: Path) -> None:
         """Gamma area and LIA for the same tile/orbit are grouped together."""
         data = np.ones((SIZE, SIZE), dtype=np.float32)

--- a/tests/test_s1_rtc_ingest.py
+++ b/tests/test_s1_rtc_ingest.py
@@ -35,6 +35,7 @@ from pydantic_zarr.v3 import GroupSpec
 SIZE = 256
 CRS = "EPSG:32633"
 XMIN, YMIN, XMAX, YMAX = 500000.0, 4997440.0, 502560.0, 5000000.0
+BOUNDS = (XMIN, YMIN, XMAX, YMAX)
 TRANSFORM = from_bounds(XMIN, YMIN, XMAX, YMAX, SIZE, SIZE)
 
 ACQ1_TAGS = {
@@ -783,6 +784,70 @@ class TestIngestConditions:
         assert model.ascending.conditions is not None
         assert "gamma_area_037" in model.ascending.conditions.members
 
+    def test_lia_only_fails_schema_validation(
+        self, s1_store_with_acquisition: Path, lia_geotiff: Path
+    ) -> None:
+        """LIA-only ingestion succeeds but the store fails schema validation
+        because S1RtcConditionsGroup requires at least one gamma_area_* array."""
+        ingest_s1tiling_conditions(
+            s1_store_with_acquisition, "ascending", 37, lia_path=lia_geotiff
+        )
+        root = zarr.open_group(str(s1_store_with_acquisition), mode="r", zarr_format=3)
+        assert "lia_037" in root["ascending"]["conditions"]
+
+        untyped = GroupSpec.from_zarr(root).model_dump()
+        with pytest.raises(ValueError, match="gamma_area_"):
+            S1RtcRoot(**untyped)
+
+    def test_cross_file_crs_mismatch(
+        self, s1_store_with_acquisition: Path, gamma_area_geotiff: Path, tmp_path: Path
+    ) -> None:
+        """Second condition file with different CRS is rejected."""
+        data = np.ones((SIZE, SIZE), dtype=np.float32)
+        wrong_lia = tmp_path / "sin_LIA_32TQM_037_wrong.tif"
+        _create_synthetic_geotiff(wrong_lia, data, crs="EPSG:32632")
+        with pytest.raises(ValueError, match="CRS mismatch"):
+            ingest_s1tiling_conditions(
+                s1_store_with_acquisition, "ascending", 37,
+                gamma_area_path=gamma_area_geotiff,
+                lia_path=wrong_lia,
+            )
+
+    def test_cross_file_shape_mismatch(
+        self, s1_store_with_acquisition: Path, gamma_area_geotiff: Path, tmp_path: Path
+    ) -> None:
+        """Second condition file with different shape/transform is rejected."""
+        data = np.ones((SIZE // 2, SIZE // 2), dtype=np.float32)
+        wrong_lia = tmp_path / "sin_LIA_32TQM_037_wrong.tif"
+        transform = rasterio.transform.from_bounds(*BOUNDS, SIZE // 2, SIZE // 2)
+        _create_synthetic_geotiff(wrong_lia, data, transform=transform)
+        with pytest.raises(ValueError, match="mismatch"):
+            ingest_s1tiling_conditions(
+                s1_store_with_acquisition, "ascending", 37,
+                gamma_area_path=gamma_area_geotiff,
+                lia_path=wrong_lia,
+            )
+
+    def test_overwrite_shape_mismatch_rejected(
+        self, s1_store_with_acquisition: Path, tmp_path: Path
+    ) -> None:
+        """Overwriting with a different shape raises ValueError."""
+        ga_path = tmp_path / "GAMMA_AREA_32TQM_037.tif"
+
+        data_v1 = np.ones((SIZE, SIZE), dtype=np.float32)
+        _create_synthetic_geotiff(ga_path, data_v1)
+        ingest_s1tiling_conditions(
+            s1_store_with_acquisition, "ascending", 37, gamma_area_path=ga_path
+        )
+
+        data_v2 = np.ones((SIZE // 2, SIZE // 2), dtype=np.float32)
+        transform = rasterio.transform.from_bounds(*BOUNDS, SIZE // 2, SIZE // 2)
+        _create_synthetic_geotiff(ga_path, data_v2, transform=transform)
+        with pytest.raises(ValueError, match="Shape mismatch"):
+            ingest_s1tiling_conditions(
+                s1_store_with_acquisition, "ascending", 37, gamma_area_path=ga_path
+            )
+
 
 # =============================================================================
 # Phase 3: Conditions file discovery tests
@@ -811,6 +876,16 @@ class TestDiscoverConditions:
         assert len(conditions) == 1
         assert "lia" in conditions[0]
 
+    def test_discovers_incidence_angle(self, tmp_path: Path) -> None:
+        data = np.ones((SIZE, SIZE), dtype=np.float32)
+        _create_synthetic_geotiff(tmp_path / "incidence_angle_32TQM_037.tif", data)
+
+        conditions = discover_s1tiling_conditions(tmp_path)
+        assert len(conditions) == 1
+        assert "incidence_angle" in conditions[0]
+        assert conditions[0]["tile"] == "32TQM"
+        assert conditions[0]["orbit"] == "037"
+
     def test_groups_gamma_area_and_lia(self, tmp_path: Path) -> None:
         """Gamma area and LIA for the same tile/orbit are grouped together."""
         data = np.ones((SIZE, SIZE), dtype=np.float32)
@@ -823,6 +898,19 @@ class TestDiscoverConditions:
         assert "lia" in conditions[0]
         assert conditions[0]["tile"] == "32TQM"
         assert conditions[0]["orbit"] == "037"
+
+    def test_groups_all_condition_types(self, tmp_path: Path) -> None:
+        """All three condition types for the same tile/orbit are grouped together."""
+        data = np.ones((SIZE, SIZE), dtype=np.float32)
+        _create_synthetic_geotiff(tmp_path / "GAMMA_AREA_32TQM_037.tif", data)
+        _create_synthetic_geotiff(tmp_path / "sin_LIA_32TQM_037.tif", data)
+        _create_synthetic_geotiff(tmp_path / "incidence_angle_32TQM_037.tif", data)
+
+        conditions = discover_s1tiling_conditions(tmp_path)
+        assert len(conditions) == 1
+        assert "gamma_area" in conditions[0]
+        assert "lia" in conditions[0]
+        assert "incidence_angle" in conditions[0]
 
     def test_skips_non_matching(self, tmp_path: Path) -> None:
         data = np.ones((SIZE, SIZE), dtype=np.float32)

--- a/tests/test_s1_rtc_ingest.py
+++ b/tests/test_s1_rtc_ingest.py
@@ -19,8 +19,10 @@ from eopf_geozarr.conversion.s1_ingest import (
     consolidate_s1_store,
     create_s1_store,
     discover_s1tiling_acquisitions,
+    discover_s1tiling_conditions,
     extract_geotiff_metadata,
     ingest_s1tiling_acquisition,
+    ingest_s1tiling_conditions,
     parse_s1tiling_filename,
 )
 from eopf_geozarr.data_api.s1_rtc import S1RtcRoot
@@ -543,3 +545,291 @@ class TestSchemaValidation:
         assert "vv" in model.ascending.r10m.members
         assert "x" in model.ascending.r10m.members
         assert "y" in model.ascending.r10m.members
+
+
+# =============================================================================
+# Phase 3: Conditions ingestion tests
+# =============================================================================
+
+
+@pytest.fixture
+def s1_store_with_acquisition(s1_geotiff_dir: Path, tmp_path: Path) -> Path:
+    """Create a Zarr store with one ingested acquisition (prerequisite for conditions)."""
+    store_path = tmp_path / "s1-grd-rtc-cond.zarr"
+    vv = s1_geotiff_dir / "s1a_32TQM_vv_ASC_037_20230115t061234_GammaNaughtRTC.tif"
+    vh = s1_geotiff_dir / "s1a_32TQM_vh_ASC_037_20230115t061234_GammaNaughtRTC.tif"
+    mask = s1_geotiff_dir / "s1a_32TQM_vv_ASC_037_20230115t061234_GammaNaughtRTC_BorderMask.tif"
+    ingest_s1tiling_acquisition(vv, vh, mask, store_path, "ascending")
+    return store_path
+
+
+@pytest.fixture
+def gamma_area_geotiff(tmp_path: Path) -> Path:
+    """Create a synthetic gamma_area GeoTIFF."""
+    rng = np.random.default_rng(99)
+    data = rng.uniform(0.5, 2.0, (SIZE, SIZE)).astype(np.float32)
+    path = tmp_path / "GAMMA_AREA_32TQM_037.tif"
+    _create_synthetic_geotiff(path, data)
+    return path
+
+
+@pytest.fixture
+def lia_geotiff(tmp_path: Path) -> Path:
+    """Create a synthetic LIA GeoTIFF."""
+    rng = np.random.default_rng(100)
+    data = rng.uniform(0.0, 1.0, (SIZE, SIZE)).astype(np.float32)
+    path = tmp_path / "sin_LIA_32TQM_037.tif"
+    _create_synthetic_geotiff(path, data)
+    return path
+
+
+class TestIngestConditions:
+    def test_gamma_area_creates_conditions_group(
+        self, s1_store_with_acquisition: Path, gamma_area_geotiff: Path
+    ) -> None:
+        ingest_s1tiling_conditions(
+            store_path=s1_store_with_acquisition,
+            orbit_direction="ascending",
+            relative_orbit=37,
+            gamma_area_path=gamma_area_geotiff,
+        )
+        root = zarr.open_group(str(s1_store_with_acquisition), mode="r", zarr_format=3)
+        orbit = root["ascending"]
+        assert "conditions" in orbit
+        conditions = orbit["conditions"]
+        assert "gamma_area_037" in conditions
+
+    def test_conditions_group_attributes(
+        self, s1_store_with_acquisition: Path, gamma_area_geotiff: Path
+    ) -> None:
+        ingest_s1tiling_conditions(
+            store_path=s1_store_with_acquisition,
+            orbit_direction="ascending",
+            relative_orbit=37,
+            gamma_area_path=gamma_area_geotiff,
+        )
+        root = zarr.open_group(str(s1_store_with_acquisition), mode="r", zarr_format=3)
+        conditions = root["ascending"]["conditions"]
+        attrs = dict(conditions.attrs)
+        assert attrs["proj:code"] == CRS
+        assert attrs["spatial:dimensions"] == ["y", "x"]
+        assert len(attrs["spatial:transform"]) == 6
+        assert attrs["spatial:shape"] == [SIZE, SIZE]
+
+    def test_gamma_area_array_shape_and_dtype(
+        self, s1_store_with_acquisition: Path, gamma_area_geotiff: Path
+    ) -> None:
+        ingest_s1tiling_conditions(
+            store_path=s1_store_with_acquisition,
+            orbit_direction="ascending",
+            relative_orbit=37,
+            gamma_area_path=gamma_area_geotiff,
+        )
+        root = zarr.open_group(str(s1_store_with_acquisition), mode="r", zarr_format=3)
+        arr = root["ascending"]["conditions"]["gamma_area_037"]
+        assert arr.shape == (SIZE, SIZE)
+        assert arr.dtype == np.float32
+        assert arr.metadata.dimension_names == ("y", "x")
+
+    def test_data_integrity_roundtrip(
+        self, s1_store_with_acquisition: Path, gamma_area_geotiff: Path
+    ) -> None:
+        ingest_s1tiling_conditions(
+            store_path=s1_store_with_acquisition,
+            orbit_direction="ascending",
+            relative_orbit=37,
+            gamma_area_path=gamma_area_geotiff,
+        )
+        # Read original
+        with rasterio.open(str(gamma_area_geotiff)) as src:
+            expected = src.read(1).astype(np.float32)
+        # Read from Zarr
+        root = zarr.open_group(str(s1_store_with_acquisition), mode="r", zarr_format=3)
+        actual = root["ascending"]["conditions"]["gamma_area_037"][:]
+        np.testing.assert_allclose(actual, expected, rtol=1e-6)
+
+    def test_multiple_conditions(
+        self, s1_store_with_acquisition: Path, gamma_area_geotiff: Path, lia_geotiff: Path
+    ) -> None:
+        ingest_s1tiling_conditions(
+            store_path=s1_store_with_acquisition,
+            orbit_direction="ascending",
+            relative_orbit=37,
+            gamma_area_path=gamma_area_geotiff,
+            lia_path=lia_geotiff,
+        )
+        root = zarr.open_group(str(s1_store_with_acquisition), mode="r", zarr_format=3)
+        conditions = root["ascending"]["conditions"]
+        assert "gamma_area_037" in conditions
+        assert "lia_037" in conditions
+
+    def test_multiple_orbits(
+        self, s1_store_with_acquisition: Path, tmp_path: Path
+    ) -> None:
+        """Conditions for different orbits create separate arrays."""
+        rng = np.random.default_rng(101)
+        ga_037 = tmp_path / "GAMMA_AREA_32TQM_037.tif"
+        ga_110 = tmp_path / "GAMMA_AREA_32TQM_110.tif"
+        _create_synthetic_geotiff(ga_037, rng.uniform(0.5, 2.0, (SIZE, SIZE)).astype(np.float32))
+        _create_synthetic_geotiff(ga_110, rng.uniform(0.5, 2.0, (SIZE, SIZE)).astype(np.float32))
+
+        ingest_s1tiling_conditions(
+            s1_store_with_acquisition, "ascending", 37, gamma_area_path=ga_037
+        )
+        ingest_s1tiling_conditions(
+            s1_store_with_acquisition, "ascending", 110, gamma_area_path=ga_110
+        )
+
+        root = zarr.open_group(str(s1_store_with_acquisition), mode="r", zarr_format=3)
+        conditions = root["ascending"]["conditions"]
+        assert "gamma_area_037" in conditions
+        assert "gamma_area_110" in conditions
+
+    def test_overwrite_existing_condition(
+        self, s1_store_with_acquisition: Path, tmp_path: Path
+    ) -> None:
+        """Writing the same condition array twice overwrites data."""
+        ga_path = tmp_path / "GAMMA_AREA_32TQM_037.tif"
+
+        data_v1 = np.ones((SIZE, SIZE), dtype=np.float32)
+        _create_synthetic_geotiff(ga_path, data_v1)
+        ingest_s1tiling_conditions(
+            s1_store_with_acquisition, "ascending", 37, gamma_area_path=ga_path
+        )
+
+        data_v2 = np.full((SIZE, SIZE), 2.0, dtype=np.float32)
+        _create_synthetic_geotiff(ga_path, data_v2)
+        ingest_s1tiling_conditions(
+            s1_store_with_acquisition, "ascending", 37, gamma_area_path=ga_path
+        )
+
+        root = zarr.open_group(str(s1_store_with_acquisition), mode="r", zarr_format=3)
+        actual = root["ascending"]["conditions"]["gamma_area_037"][:]
+        np.testing.assert_allclose(actual, data_v2, rtol=1e-6)
+
+    def test_raises_no_conditions_provided(
+        self, s1_store_with_acquisition: Path
+    ) -> None:
+        with pytest.raises(ValueError, match="At least one condition"):
+            ingest_s1tiling_conditions(
+                s1_store_with_acquisition, "ascending", 37
+            )
+
+    def test_raises_store_not_exists(self, tmp_path: Path, gamma_area_geotiff: Path) -> None:
+        with pytest.raises(ValueError, match="Store does not exist"):
+            ingest_s1tiling_conditions(
+                tmp_path / "nonexistent.zarr", "ascending", 37,
+                gamma_area_path=gamma_area_geotiff,
+            )
+
+    def test_raises_orbit_not_exists(
+        self, tmp_path: Path, gamma_area_geotiff: Path
+    ) -> None:
+        """Raise if the orbit group hasn't been created yet."""
+        store_path = tmp_path / "empty-store.zarr"
+        zarr.open_group(str(store_path), mode="w-", zarr_format=3)
+        with pytest.raises(ValueError, match="not found in store"):
+            ingest_s1tiling_conditions(
+                store_path, "ascending", 37, gamma_area_path=gamma_area_geotiff
+            )
+
+    def test_raises_file_not_found(self, s1_store_with_acquisition: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            ingest_s1tiling_conditions(
+                s1_store_with_acquisition, "ascending", 37,
+                gamma_area_path="/nonexistent/gamma_area.tif",
+            )
+
+    def test_consolidation_includes_conditions(
+        self, s1_store_with_acquisition: Path, gamma_area_geotiff: Path
+    ) -> None:
+        """Consolidation after conditions ingestion includes the conditions group."""
+        ingest_s1tiling_conditions(
+            s1_store_with_acquisition, "ascending", 37, gamma_area_path=gamma_area_geotiff
+        )
+        consolidate_s1_store(s1_store_with_acquisition, "ascending")
+
+        root = zarr.open_group(str(s1_store_with_acquisition), mode="r", zarr_format=3)
+        assert root.metadata.consolidated_metadata is not None
+        orbit = root["ascending"]
+        assert orbit.metadata.consolidated_metadata is not None
+        assert "conditions" in orbit
+        assert "gamma_area_037" in orbit["conditions"]
+
+    def test_crs_mismatch_rejected(
+        self, s1_store_with_acquisition: Path, tmp_path: Path
+    ) -> None:
+        """Conditions with a different CRS than the store are rejected."""
+        data = np.ones((SIZE, SIZE), dtype=np.float32)
+        wrong_crs_path = tmp_path / "GAMMA_AREA_32TQM_037_wrong.tif"
+        _create_synthetic_geotiff(wrong_crs_path, data, crs="EPSG:32632")
+        with pytest.raises(ValueError, match="CRS mismatch"):
+            ingest_s1tiling_conditions(
+                s1_store_with_acquisition, "ascending", 37,
+                gamma_area_path=wrong_crs_path,
+            )
+
+    def test_schema_validation_with_conditions(
+        self, s1_store_with_acquisition: Path, gamma_area_geotiff: Path
+    ) -> None:
+        """Store with conditions validates against S1RtcRoot schema."""
+        ingest_s1tiling_conditions(
+            s1_store_with_acquisition, "ascending", 37, gamma_area_path=gamma_area_geotiff
+        )
+        root = zarr.open_group(str(s1_store_with_acquisition), mode="r", zarr_format=3)
+        untyped = GroupSpec.from_zarr(root).model_dump()
+        model = S1RtcRoot(**untyped)
+        assert model.ascending is not None
+        assert model.ascending.conditions is not None
+        assert "gamma_area_037" in model.ascending.conditions.members
+
+
+# =============================================================================
+# Phase 3: Conditions file discovery tests
+# =============================================================================
+
+
+class TestDiscoverConditions:
+    def test_discovers_gamma_area(self, tmp_path: Path) -> None:
+        data = np.ones((SIZE, SIZE), dtype=np.float32)
+        _create_synthetic_geotiff(tmp_path / "GAMMA_AREA_32TQM_037.tif", data)
+        _create_synthetic_geotiff(tmp_path / "GAMMA_AREA_32TQM_110.tif", data)
+
+        conditions = discover_s1tiling_conditions(tmp_path)
+        assert len(conditions) == 2
+        orbits = {c["orbit"] for c in conditions}
+        assert orbits == {"037", "110"}
+        for c in conditions:
+            assert "gamma_area" in c
+            assert c["tile"] == "32TQM"
+
+    def test_discovers_lia(self, tmp_path: Path) -> None:
+        data = np.ones((SIZE, SIZE), dtype=np.float32)
+        _create_synthetic_geotiff(tmp_path / "sin_LIA_32TQM_037.tif", data)
+
+        conditions = discover_s1tiling_conditions(tmp_path)
+        assert len(conditions) == 1
+        assert "lia" in conditions[0]
+
+    def test_groups_gamma_area_and_lia(self, tmp_path: Path) -> None:
+        """Gamma area and LIA for the same tile/orbit are grouped together."""
+        data = np.ones((SIZE, SIZE), dtype=np.float32)
+        _create_synthetic_geotiff(tmp_path / "GAMMA_AREA_32TQM_037.tif", data)
+        _create_synthetic_geotiff(tmp_path / "sin_LIA_32TQM_037.tif", data)
+
+        conditions = discover_s1tiling_conditions(tmp_path)
+        assert len(conditions) == 1
+        assert "gamma_area" in conditions[0]
+        assert "lia" in conditions[0]
+        assert conditions[0]["tile"] == "32TQM"
+        assert conditions[0]["orbit"] == "037"
+
+    def test_skips_non_matching(self, tmp_path: Path) -> None:
+        data = np.ones((SIZE, SIZE), dtype=np.float32)
+        _create_synthetic_geotiff(tmp_path / "random_file.tif", data)
+        conditions = discover_s1tiling_conditions(tmp_path)
+        assert len(conditions) == 0
+
+    def test_empty_directory(self, tmp_path: Path) -> None:
+        conditions = discover_s1tiling_conditions(tmp_path)
+        assert len(conditions) == 0


### PR DESCRIPTION
## Phase 3 — S1Tiling Conditions Ingestion and Discovery

Adds support for ingesting time-invariant per-orbit condition arrays (gamma_area, LIA, incidence_angle) into a `conditions` group under each orbit direction.

Closes part of #139 (Phase 3).

### Changes

**`src/eopf_geozarr/conversion/s1_ingest.py`**
- `S1TILING_GAMMA_AREA_PATTERN` / `S1TILING_LIA_PATTERN` — regex constants for condition file discovery
- `ingest_s1tiling_conditions()` — creates conditions group with proj:/spatial: attrs, writes per-orbit `(Y, X)` arrays
- `discover_s1tiling_conditions()` — groups condition GeoTIFFs by tile + orbit

**`src/eopf_geozarr/cli.py`**
- `ingest-s1` — ingest a single acquisition (VV + VH + mask)
- `ingest-s1-conditions` — ingest condition arrays for an orbit
- `consolidate-s1` — post-batch consolidation

**`src/eopf_geozarr/conversion/__init__.py`**
- Added `discover_s1tiling_conditions` and `ingest_s1tiling_conditions` to exports

**`tests/test_s1_rtc_ingest.py`**
- 20 new tests across `TestIngestConditions` (14 tests) and `TestDiscoverConditions` (5 tests)
- Total: 47/47 passing

### Test summary

| Class | Tests | Covers |
|-------|-------|--------|
| `TestIngestConditions` | 14 | Group creation, attributes, shape/dtype, data roundtrip, multiple conditions, multiple orbits, overwrite, error cases (no conditions, store not exists, orbit not exists, file not found, CRS mismatch), consolidation, schema validation |
| `TestDiscoverConditions` | 5 | Gamma area discovery, LIA discovery, grouping, skips non-matching, empty directory |