### PR TITLE
feat: Phase 4 — CLI and S3 (#139)

### DIFF
--- a/src/eopf_geozarr/cli.py
+++ b/src/eopf_geozarr/cli.py
@@ -1074,6 +1074,58 @@ def consolidate_s1_command(args: argparse.Namespace) -> None:
         sys.exit(1)
 
 
+def validate_s1_command(args: argparse.Namespace) -> None:
+    """Validate an S1 GRD RTC GeoZarr V3 store against the schema."""
+    import zarr
+    from pydantic_zarr.v3 import GroupSpec
+
+    from .conversion.fs_utils import open_zarr_group, path_exists
+    from .data_api.s1_rtc import S1RtcRoot
+
+    store_path = args.store
+    if not path_exists(store_path):
+        log.error("❌ Store does not exist", store=store_path)
+        sys.exit(1)
+
+    try:
+        root = open_zarr_group(store_path, mode="r")
+        untyped = GroupSpec.from_zarr(root).model_dump()
+        model = S1RtcRoot(**untyped)
+
+        orbit_dirs = []
+        if model.ascending is not None:
+            orbit_dirs.append("ascending")
+        if model.descending is not None:
+            orbit_dirs.append("descending")
+
+        log.info("✅ S1 RTC store is valid", store=store_path, orbit_dirs=orbit_dirs)
+
+        if args.verbose:
+            for od in orbit_dirs:
+                orbit = getattr(model, od)
+                data_arrays = [
+                    k for k in orbit.r10m.members
+                    if k not in ("x", "y", "time", "absolute_orbit", "relative_orbit", "platform")
+                ]
+                coord_vars = [
+                    k for k in orbit.r10m.members
+                    if k in ("time", "absolute_orbit", "relative_orbit", "platform")
+                ]
+                log.info(
+                    f"  {od}",
+                    data_arrays=data_arrays,
+                    coordinates=coord_vars,
+                    has_conditions=orbit.conditions is not None,
+                )
+    except Exception as e:
+        log.error("❌ Validation failed", store=store_path, error=str(e))
+        if args.verbose:
+            import traceback
+
+            traceback.print_exc()
+        sys.exit(1)
+
+
 def create_parser() -> argparse.ArgumentParser:
     """
     Create the argument parser for the CLI.
@@ -1250,6 +1302,14 @@ def add_s1_ingestion_commands(subparsers: argparse._SubParsersAction) -> None:
         help="Orbit direction",
     )
     cons_parser.set_defaults(func=consolidate_s1_command)
+
+    # validate-s1: schema validation
+    val_parser = subparsers.add_parser(
+        "validate-s1", help="Validate an S1 GRD RTC GeoZarr V3 store against the schema"
+    )
+    val_parser.add_argument("--store", type=str, required=True, help="Path to Zarr V3 store")
+    val_parser.add_argument("--verbose", action="store_true", help="Enable verbose output")
+    val_parser.set_defaults(func=validate_s1_command)
 
 
 def add_s2_optimization_commands(subparsers: argparse._SubParsersAction) -> None:

--- a/src/eopf_geozarr/conversion/s1_ingest.py
+++ b/src/eopf_geozarr/conversion/s1_ingest.py
@@ -27,6 +27,10 @@ import zarr
 import zarr.codecs
 from zarr_cm import geo_proj, multiscales as multiscales_cm, spatial as spatial_cm
 
+from eopf_geozarr.conversion.fs_utils import (
+    open_zarr_group,
+    path_exists,
+)
 from eopf_geozarr.conversion.utils import (
     calculate_aligned_chunk_size,
     calculate_shard_dimension,
@@ -397,7 +401,7 @@ def create_s1_store(
 
     Returns the root group.
     """
-    root = zarr.open_group(str(store_path), mode="w-", zarr_format=3)
+    root = open_zarr_group(str(store_path), mode="w-")
     _create_orbit_group(root, orbit_direction, metadata)
 
     log.info(
@@ -455,7 +459,7 @@ def ingest_s1tiling_acquisition(
     vv_path = Path(vv_path)
     vh_path = Path(vh_path)
     border_mask_path = Path(border_mask_path)
-    store_path = Path(store_path)
+    store_path_str = str(store_path)
 
     for p in [vv_path, vh_path, border_mask_path]:
         if not p.exists():
@@ -494,10 +498,10 @@ def ingest_s1tiling_acquisition(
     )
 
     # Create-or-open store
-    if not store_path.exists():
-        root = create_s1_store(store_path, orbit_direction, meta)
+    if not path_exists(store_path_str):
+        root = create_s1_store(store_path_str, orbit_direction, meta)
     else:
-        root = zarr.open_group(str(store_path), mode="r+", zarr_format=3)
+        root = open_zarr_group(store_path_str, mode="r+")
         if orbit_direction not in root:
             # Validate against existing orbit groups before creating a new one
             for existing_name in root.members:
@@ -626,11 +630,13 @@ def consolidate_s1_store(store_path: str | Path, orbit_direction: str) -> None:
     Must be called AFTER all ingestions complete — consolidated metadata
     caches array shapes and will become stale if called mid-ingestion.
     """
-    zarr.consolidate_metadata(str(store_path), path=orbit_direction, zarr_format=3)
-    zarr.consolidate_metadata(str(store_path), zarr_format=3)
+    store_path_str = str(store_path)
+    root = open_zarr_group(store_path_str, mode="r+")
+    zarr.consolidate_metadata(root.store, path=orbit_direction, zarr_format=3)
+    zarr.consolidate_metadata(root.store, zarr_format=3)
     log.info(
         "Metadata consolidated",
-        store_path=str(store_path),
+        store_path=store_path_str,
         orbit_direction=orbit_direction,
     )
 
@@ -761,13 +767,13 @@ def ingest_s1tiling_conditions(
     if not condition_inputs:
         raise ValueError("At least one condition path must be provided")
 
-    store_path = Path(store_path)
-    if not store_path.exists():
-        raise ValueError(f"Store does not exist: {store_path}")
+    store_path_str = str(store_path)
+    if not path_exists(store_path_str):
+        raise ValueError(f"Store does not exist: {store_path_str}")
 
     orbit_suffix = f"{relative_orbit:03d}"
 
-    root = zarr.open_group(str(store_path), mode="r+", zarr_format=3)
+    root = open_zarr_group(store_path_str, mode="r+")
     if orbit_direction not in root:
         raise ValueError(
             f"Orbit direction '{orbit_direction}' not found in store. "

--- a/tests/test_cli_e2e.py
+++ b/tests/test_cli_e2e.py
@@ -310,3 +310,144 @@ def test_cli_crs_groups_empty_list(tmp_path: str) -> None:
     # Should succeed (empty crs_groups list is valid)
     assert result.returncode == 0, f"CLI with empty --crs-groups failed: {result.stderr}"
     assert "CRS groups: []" in result.stdout, "Should show empty CRS groups list"
+
+
+# =============================================================================
+# S1 RTC CLI E2E tests
+# =============================================================================
+
+
+@pytest.fixture()
+def s1_cli_geotiff_dir(tmp_path: Path) -> Path:
+    """Create synthetic S1Tiling GeoTIFFs for CLI E2E tests."""
+    import numpy as np
+    import rasterio
+    from rasterio.transform import from_bounds
+
+    size = 256
+    xmin, ymin, xmax, ymax = 500000.0, 4997440.0, 502560.0, 5000000.0
+    transform = from_bounds(xmin, ymin, xmax, ymax, size, size)
+    crs = "EPSG:32633"
+    rng = np.random.default_rng(42)
+
+    tags = {
+        "ACQUISITION_DATETIME": "2023:01:15T06:12:34Z",
+        "ORBIT_NUMBER": "47001",
+        "RELATIVE_ORBIT_NUMBER": "037",
+        "FLYING_UNIT_CODE": "S1A",
+        "CALIBRATION": "gamma_naught",
+        "INPUT_S1_IMAGES": "S1A_IW_GRDH_1SDV_20230115",
+    }
+
+    def _write(filename: str, data: np.ndarray, t: dict | None = None) -> None:
+        with rasterio.open(
+            str(tmp_path / filename), "w", driver="GTiff",
+            height=data.shape[0], width=data.shape[1], count=1,
+            dtype=data.dtype, crs=crs, transform=transform,
+        ) as dst:
+            if t:
+                dst.update_tags(**t)
+            dst.write(data, 1)
+
+    vv = rng.uniform(0.0, 1.0, (size, size)).astype(np.float32)
+    vh = rng.uniform(0.0, 0.5, (size, size)).astype(np.float32)
+    mask = np.ones((size, size), dtype=np.uint8)
+    mask[:10, :] = 0
+
+    _write("s1a_32TQM_vv_ASC_037_20230115t061234_GammaNaughtRTC.tif", vv, tags)
+    _write("s1a_32TQM_vh_ASC_037_20230115t061234_GammaNaughtRTC.tif", vh, tags)
+    _write("s1a_32TQM_vv_ASC_037_20230115t061234_GammaNaughtRTC_BorderMask.tif", mask, tags)
+
+    # Condition GeoTIFFs
+    ga = rng.uniform(0.5, 2.0, (size, size)).astype(np.float32)
+    _write("GAMMA_AREA_32TQM_037.tif", ga)
+
+    return tmp_path
+
+
+def test_s1_ingest_cli(s1_cli_geotiff_dir: Path, tmp_path: Path) -> None:
+    """E2E: ingest-s1 → consolidate-s1 → validate-s1 via CLI."""
+    store = str(tmp_path / "s1-test.zarr")
+    geotiff_dir = s1_cli_geotiff_dir
+
+    # 1) ingest-s1
+    result = subprocess.run(
+        [
+            "python", "-m", "eopf_geozarr", "ingest-s1",
+            "--vv", str(geotiff_dir / "s1a_32TQM_vv_ASC_037_20230115t061234_GammaNaughtRTC.tif"),
+            "--vh", str(geotiff_dir / "s1a_32TQM_vh_ASC_037_20230115t061234_GammaNaughtRTC.tif"),
+            "--mask", str(geotiff_dir / "s1a_32TQM_vv_ASC_037_20230115t061234_GammaNaughtRTC_BorderMask.tif"),
+            "--store", store,
+            "--orbit-dir", "ascending",
+        ],
+        capture_output=True, text=True, timeout=120,
+    )
+    assert result.returncode == 0, f"ingest-s1 failed: {result.stderr}"
+
+    # 2) ingest-s1-conditions
+    result = subprocess.run(
+        [
+            "python", "-m", "eopf_geozarr", "ingest-s1-conditions",
+            "--store", store,
+            "--orbit-dir", "ascending",
+            "--relative-orbit", "37",
+            "--gamma-area", str(geotiff_dir / "GAMMA_AREA_32TQM_037.tif"),
+        ],
+        capture_output=True, text=True, timeout=120,
+    )
+    assert result.returncode == 0, f"ingest-s1-conditions failed: {result.stderr}"
+
+    # 3) consolidate-s1
+    result = subprocess.run(
+        [
+            "python", "-m", "eopf_geozarr", "consolidate-s1",
+            "--store", store,
+            "--orbit-dir", "ascending",
+        ],
+        capture_output=True, text=True, timeout=120,
+    )
+    assert result.returncode == 0, f"consolidate-s1 failed: {result.stderr}"
+
+    # 4) validate-s1
+    result = subprocess.run(
+        [
+            "python", "-m", "eopf_geozarr", "validate-s1",
+            "--store", store,
+            "--verbose",
+        ],
+        capture_output=True, text=True, timeout=120,
+    )
+    assert result.returncode == 0, f"validate-s1 failed: {result.stderr}"
+
+    # 5) Verify xarray can read back the store
+    ds = xr.open_zarr(str(Path(store) / "ascending" / "r10m"))
+    assert "vv" in ds
+    assert ds["vv"].shape[0] == 1
+
+
+def test_s1_validate_cli_rejects_invalid(tmp_path: Path) -> None:
+    """validate-s1 returns non-zero for an invalid store."""
+    import zarr
+
+    # Create a bare Zarr group (no orbit groups → schema validation fails)
+    store = str(tmp_path / "empty.zarr")
+    zarr.open_group(store, mode="w-", zarr_format=3)
+
+    result = subprocess.run(
+        [
+            "python", "-m", "eopf_geozarr", "validate-s1",
+            "--store", store,
+        ],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert result.returncode != 0
+
+
+def test_s1_cli_help() -> None:
+    """All S1 CLI subcommands display help."""
+    for subcmd in ["ingest-s1", "ingest-s1-conditions", "consolidate-s1", "validate-s1"]:
+        result = subprocess.run(
+            ["python", "-m", "eopf_geozarr", subcmd, "--help"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, f"{subcmd} --help failed"


### PR DESCRIPTION
## Phase 4 — CLI and S3

Closes the Phase 4 checklist in #139.

### Changes

**`validate-s1` CLI subcommand** ([cli.py](src/eopf_geozarr/cli.py))
- Validates an S1 RTC store against the `S1RtcRoot` Pydantic schema
- `--verbose` shows orbit directions, data arrays, coordinates, and conditions status
- Supports both local and S3 paths

**S3 output support** ([s1_ingest.py](src/eopf_geozarr/conversion/s1_ingest.py))
- `create_s1_store` / `ingest_s1tiling_acquisition` / `ingest_s1tiling_conditions` now use `open_zarr_group()` and `path_exists()` from `fs_utils`, making them S3-transparent
- `consolidate_s1_store` follows the S2 pattern: opens the store, passes `root.store` to `zarr.consolidate_metadata()`

**E2E CLI test** ([test_cli_e2e.py](tests/test_cli_e2e.py))
- Full pipeline: `ingest-s1` → `ingest-s1-conditions` → `consolidate-s1` → `validate-s1` → xarray readback
- Negative test: `validate-s1` on an invalid store returns non-zero
- Help test: all 4 S1 subcommands (`ingest-s1`, `ingest-s1-conditions`, `consolidate-s1`, `validate-s1`)

### CLI subcommands (complete set after Phase 3 + 4)

| Subcommand | Description |
|---|---|
| `ingest-s1` | Ingest VV + VH + border mask GeoTIFFs |
| `ingest-s1-conditions` | Ingest gamma_area / LIA / incidence_angle |
| `consolidate-s1` | Post-batch Zarr metadata consolidation |
| `validate-s1` | Schema validation against `S1RtcRoot` |

### Test results

- **54** existing S1 tests ✅
- **3** new E2E CLI tests ✅