### PR TITLE
fix: support s3:// URIs in S1Tiling discovery and ingest

### DIFF
--- a/src/eopf_geozarr/conversion/s1_ingest.py
+++ b/src/eopf_geozarr/conversion/s1_ingest.py
@@ -128,7 +128,7 @@ def extract_geotiff_metadata(path: str | Path) -> S1TilingMetadata:
         If critical tags (ACQUISITION_DATETIME, ORBIT_NUMBER,
         RELATIVE_ORBIT_NUMBER, FLYING_UNIT_CODE) are missing.
     """
-    with rasterio.open(str(path)) as src:
+    with _rasterio_env(path), rasterio.open(str(path)) as src:
         tags = src.tags()
         t = src.transform
         spatial_transform = [t.a, t.b, t.c, t.d, t.e, t.f]
@@ -468,13 +468,13 @@ def ingest_s1tiling_acquisition(
     ValueError
         If the GeoTIFF CRS or shape does not match the existing store.
     """
-    vv_path = Path(vv_path)
-    vh_path = Path(vh_path)
-    border_mask_path = Path(border_mask_path)
+    vv_path = _coerce_input_path(vv_path)
+    vh_path = _coerce_input_path(vh_path)
+    border_mask_path = _coerce_input_path(border_mask_path)
     store_path = Path(store_path)
 
     for p in [vv_path, vh_path, border_mask_path]:
-        if not p.exists():
+        if not _input_path_exists(p):
             raise FileNotFoundError(f"GeoTIFF not found: {p}")
 
     # Extract metadata from VV file
@@ -581,12 +581,13 @@ def ingest_s1tiling_acquisition(
     orbit = root[orbit_direction]
 
     # Read GeoTIFF pixel data
-    with rasterio.open(str(vv_path)) as src:
-        vv_data = src.read(1)
-    with rasterio.open(str(vh_path)) as src:
-        vh_data = src.read(1)
-    with rasterio.open(str(border_mask_path)) as src:
-        mask_data = src.read(1).astype(np.uint8)
+    with _rasterio_env(vv_path):
+        with rasterio.open(str(vv_path)) as src:
+            vv_data = src.read(1)
+        with rasterio.open(str(vh_path)) as src:
+            vh_data = src.read(1)
+        with rasterio.open(str(border_mask_path)) as src:
+            mask_data = src.read(1).astype(np.uint8)
 
     log.info(
         "GeoTIFF read complete",
@@ -664,6 +665,62 @@ def consolidate_s1_store(store_path: str | Path, orbit_direction: str) -> None:
 
 
 # =============================================================================
+# S3 / local filesystem helpers
+# =============================================================================
+
+
+def _list_tifs(input_dir: str | Path) -> list[str | Path]:
+    """List *.tif files; supports local paths and s3:// URIs."""
+    s = str(input_dir).rstrip("/")
+    if s.startswith("s3://"):
+        import s3fs as _s3
+
+        fs = _s3.S3FileSystem()
+        bucket_key = s[len("s3://") :]
+        return [f"s3://{p}" for p in sorted(fs.glob(f"{bucket_key}/*.tif"))]
+    return sorted(Path(input_dir).glob("*.tif"))
+
+
+def _coerce_input_path(p: str | Path) -> str | Path:
+    """Return str for s3:// URIs (preserves double-slash); Path otherwise."""
+    s = str(p)
+    return s if s.startswith("s3://") else Path(s)
+
+
+def _input_path_exists(p: str | Path) -> bool:
+    """Existence check for both local Path and s3:// URI."""
+    s = str(p)
+    if s.startswith("s3://"):
+        import s3fs as _s3
+
+        return _s3.S3FileSystem().exists(s.removeprefix("s3://"))
+    return Path(p).exists()
+
+
+def _rasterio_env(path: str | Path):  # type: ignore[return]
+    """rasterio.Env context for S3 paths; no-op context manager for local paths.
+
+    rasterio 1.5 passes endpoint_url verbatim as GDAL's AWS_S3_ENDPOINT.
+    GDAL expects hostname only (no scheme), so strip https:// from
+    AWS_ENDPOINT_URL if that is what the environment provides.
+    """
+    import contextlib
+    import os
+
+    if not str(path).startswith("s3://"):
+        return contextlib.nullcontext()
+
+    import boto3
+    import rasterio
+    from rasterio.session import AWSSession
+
+    raw = os.environ.get("AWS_S3_ENDPOINT") or os.environ.get("AWS_ENDPOINT_URL", "")
+    endpoint = raw.split("://", 1)[-1] if "://" in raw else raw
+    session = boto3.Session()
+    return rasterio.Env(AWSSession(session, endpoint_url=endpoint or None))
+
+
+# =============================================================================
 # File Discovery
 # =============================================================================
 
@@ -676,12 +733,11 @@ def discover_s1tiling_acquisitions(input_dir: str | Path) -> list[dict]:
 
     Logs warnings for incomplete acquisitions (missing polarisation or mask files).
     """
-    input_dir = Path(input_dir)
-    files = sorted(input_dir.glob("*.tif"))
+    files = _list_tifs(input_dir)
     groups: dict[tuple, dict] = {}
 
     for f in files:
-        parsed = parse_s1tiling_filename(f.name)
+        parsed = parse_s1tiling_filename(Path(str(f)).name)
         if parsed is None:
             continue
 
@@ -772,8 +828,8 @@ def ingest_s1tiling_conditions(
         ("incidence_angle", incidence_angle_path),
     ]:
         if path is not None:
-            p = Path(path)
-            if not p.exists():
+            p = _coerce_input_path(path)
+            if not _input_path_exists(p):
                 raise FileNotFoundError(f"Condition GeoTIFF not found: {p}")
             condition_inputs.append((label, p))
 
@@ -797,7 +853,7 @@ def ingest_s1tiling_conditions(
 
     # Read reference metadata from the first condition file
     ref_label, ref_path = condition_inputs[0]
-    with rasterio.open(str(ref_path)) as src:
+    with _rasterio_env(ref_path), rasterio.open(str(ref_path)) as src:
         ref_crs = str(src.crs)
         t = src.transform
         ref_transform = [t.a, t.b, t.c, t.d, t.e, t.f]
@@ -829,7 +885,7 @@ def ingest_s1tiling_conditions(
     for label, cond_path in condition_inputs:
         array_name = f"{label}_{orbit_suffix}"
 
-        with rasterio.open(str(cond_path)) as src:
+        with _rasterio_env(cond_path), rasterio.open(str(cond_path)) as src:
             data = src.read(1).astype(np.float32)
 
         h, w = data.shape
@@ -881,12 +937,11 @@ def discover_s1tiling_conditions(input_dir: str | Path) -> list[dict]:
 
     Groups by (tile, orbit).
     """
-    input_dir = Path(input_dir)
-    files = sorted(input_dir.glob("*.tif"))
+    files = _list_tifs(input_dir)
     groups: dict[tuple[str, str], dict] = {}
 
     for f in files:
-        m = S1TILING_GAMMA_AREA_PATTERN.match(f.name)
+        m = S1TILING_GAMMA_AREA_PATTERN.match(Path(str(f)).name)
         if m:
             tile = m.group("tile")
             orbit = m.group("orbit")
@@ -896,7 +951,7 @@ def discover_s1tiling_conditions(input_dir: str | Path) -> list[dict]:
             groups[key]["gamma_area"] = f
             continue
 
-        m = S1TILING_LIA_PATTERN.match(f.name)
+        m = S1TILING_LIA_PATTERN.match(Path(str(f)).name)
         if m:
             tile = m.group("tile")
             orbit = m.group("orbit")

--- a/tests/test_s1_rtc_ingest.py
+++ b/tests/test_s1_rtc_ingest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from math import ceil
 from pathlib import Path
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -494,6 +495,20 @@ class TestDiscoverAcquisitions:
         acqs = discover_s1tiling_acquisitions(tmp_path)
         assert len(acqs) == 0
 
+    def test_s3_uri_discovers_acquisitions(self) -> None:
+        """s3:// prefix is listed via s3fs; pathlib.glob is NOT used."""
+        s3_files = [
+            "bucket/prefix/s1a_32TQM_vv_ASC_037_20230115t061234_GammaNaughtRTC.tif",
+            "bucket/prefix/s1a_32TQM_vh_ASC_037_20230115t061234_GammaNaughtRTC.tif",
+            "bucket/prefix/s1a_32TQM_vv_ASC_037_20230115t061234_GammaNaughtRTC_BorderMask.tif",
+            "bucket/prefix/s1a_32TQM_vh_ASC_037_20230115t061234_GammaNaughtRTC_BorderMask.tif",
+        ]
+        with patch("s3fs.S3FileSystem.glob", return_value=s3_files):
+            acqs = discover_s1tiling_acquisitions("s3://bucket/prefix/")
+        assert len(acqs) == 1
+        expected_vv = "s3://bucket/prefix/s1a_32TQM_vv_ASC_037_20230115t061234_GammaNaughtRTC.tif"
+        assert acqs[0]["vv"] == expected_vv
+
 
 # =============================================================================
 # Phase 3: Conditions ingestion tests
@@ -757,3 +772,12 @@ class TestDiscoverConditions:
     def test_empty_directory(self, tmp_path: Path) -> None:
         conditions = discover_s1tiling_conditions(tmp_path)
         assert len(conditions) == 0
+
+    def test_s3_uri_discovers_conditions(self) -> None:
+        """s3:// prefix is listed via s3fs; pathlib.glob is NOT used."""
+        s3_files = ["bucket/prefix/GAMMA_AREA_32TQM_037.tif"]
+        with patch("s3fs.S3FileSystem.glob", return_value=s3_files):
+            conditions = discover_s1tiling_conditions("s3://bucket/prefix/")
+        assert len(conditions) == 1
+        assert conditions[0]["tile"] == "32TQM"
+        assert conditions[0]["orbit"] == "037"


### PR DESCRIPTION
## Summary

Fixes four functions in `s1_ingest.py` that silently failed when passed `s3://` URIs as input paths. Blocking for Sub-issue 6 (Argo ingest template), where GeoTIFFs live on OVH S3 with no local directory fallback.

Refs #139 (Phase 5 — STAC and Argo).

### Root causes

| Function | Bug | Fix |
|----------|-----|-----|
| `discover_s1tiling_acquisitions` | `pathlib.Path.glob()` normalises `s3://` → `s3:/`, returns 0 matches | replaced with `_list_tifs()` using `s3fs.S3FileSystem.glob` |
| `discover_s1tiling_conditions` | same | same |
| `ingest_s1tiling_acquisition` | `Path(path)` corrupts `s3://`; `p.exists()` always False on S3; `rasterio.open()` misses OVH endpoint | `_coerce_input_path`, `_input_path_exists`, `_rasterio_env` |
| `ingest_s1tiling_conditions` | same | same |

### New private helpers

- **`_list_tifs(input_dir)`** — `s3fs.S3FileSystem.glob` for `s3://`; `Path.glob` for local
- **`_coerce_input_path(p)`** — returns `str` for `s3://` URIs (preserves double-slash); `Path` otherwise
- **`_input_path_exists(p)`** — `s3fs.exists` for `s3://`; `Path.exists` for local
- **`_rasterio_env(path)`** — `rasterio.Env(AWSSession(...))` context for `s3://`; no-op for local. Reads endpoint from `AWS_S3_ENDPOINT` or `AWS_ENDPOINT_URL` (strips `https://` scheme — GDAL requires hostname-only)

### rasterio / OVH S3 endpoint finding (tested on rasterio 1.5.0 / GDAL 3.12.1)

rasterio 1.5.0 passes `endpoint_url` verbatim as GDAL's `AWS_S3_ENDPOINT`. GDAL expects hostname-only (no scheme). `AWS_ENDPOINT_URL` (boto3-style) is ignored by GDAL. The helper strips the scheme automatically.

## Test plan

- [x] All 44 pre-existing tests pass unchanged
- [x] `TestDiscoverAcquisitions::test_s3_uri_discovers_acquisitions` — mocked `s3fs.S3FileSystem.glob` returns correct acquisition groups from `s3://` prefix
- [x] `TestDiscoverConditions::test_s3_uri_discovers_conditions` — same for conditions

## Post-merge

Callers using OVH or other non-AWS S3 must set either `AWS_S3_ENDPOINT=hostname` (no scheme) or `AWS_ENDPOINT_URL=https://hostname` in the process environment. `_rasterio_env` handles both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)