### PR TITLE
fix(s1): write CF grid_mapping, drop tile_matrix_set from RTC store

### DIFF
--- a/src/eopf_geozarr/conversion/s1_ingest.py
+++ b/src/eopf_geozarr/conversion/s1_ingest.py
@@ -22,10 +22,10 @@ from pathlib import Path
 
 import numpy as np
 import rasterio
-import rasterio.crs
 import structlog
 import zarr
 import zarr.codecs
+from pyproj import CRS as PyprojCRS
 from zarr_cm import geo_proj
 from zarr_cm import multiscales as multiscales_cm
 from zarr_cm import spatial as spatial_cm
@@ -295,45 +295,34 @@ def _create_spatial_coordinate_arrays(
     )
 
 
-def _create_tile_matrix_set(crs_string: str, bounds: list[float], layout: list[dict]) -> dict:
-    """Build an OGC TileMatrixSet for the orbit group from the store layout.
+def _add_grid_mapping(group: zarr.Group, crs_string: str) -> None:
+    """Add a CF ``spatial_ref`` grid-mapping coordinate to a group holding (y, x) arrays.
 
-    Each resolution level becomes one tile matrix with matrixWidth=matrixHeight=1
-    (one tile covers the full MGRS tile extent), matching the GeoZarr convention
-    used by S2 measurements/reflectance groups.
+    rioxarray -- and TiTiler's GeoZarr reader -- resolve the CRS from a CF
+    ``spatial_ref``/``crs_wkt`` coordinate; the GeoZarr ``proj:code`` attribute alone
+    is not read. This mirrors the S2 converter (which writes a ``spatial_ref``
+    grid-mapping variable via ``rio.write_crs``). The CF attributes come from
+    ``pyproj.CRS.to_cf()`` -- the same source rioxarray uses -- so the projection is
+    described correctly for any CRS rather than hard-coded.
+
+    The scalar ``spatial_ref`` array is created (if absent) and every (y, x) data
+    array in the group is given ``grid_mapping = "spatial_ref"``.
     """
-    left, bottom, right, top = bounds
-    native_crs = rasterio.crs.CRS.from_string(crs_string)
-    epsg = native_crs.to_epsg()
-    crs_uri = (
-        f"http://www.opengis.net/def/crs/EPSG/0/{epsg}"
-        if epsg
-        else native_crs.to_wkt()
-    )
-    tile_matrices = []
-    for entry in layout:
-        h, w = entry["spatial:shape"]
-        cell_size = max((right - left) / w, (top - bottom) / h)
-        tile_matrices.append(
-            {
-                "id": entry["asset"],
-                "scaleDenominator": cell_size * 3779.5275,
-                "cellSize": cell_size,
-                "pointOfOrigin": [left, top],
-                "tileWidth": w,
-                "tileHeight": h,
-                "matrixWidth": 1,
-                "matrixHeight": 1,
-            }
-        )
-    return {
-        "id": f"Native_CRS_{epsg or 'Custom'}",
-        "title": f"Native CRS Tile Matrix Set (EPSG:{epsg})",
-        "crs": crs_uri,
-        "supportedCRS": crs_uri,
-        "orderedAxes": ["X", "Y"],
-        "tileMatrices": tile_matrices,
-    }
+    cf_attrs = PyprojCRS.from_user_input(crs_string).to_cf()
+    # rioxarray writes both ``crs_wkt`` and a ``spatial_ref`` attr holding the WKT.
+    cf_attrs["spatial_ref"] = cf_attrs["crs_wkt"]
+    cf_attrs["_ARRAY_DIMENSIONS"] = []
+
+    if "spatial_ref" in group:
+        sref = group["spatial_ref"]
+    else:
+        sref = group.create_array("spatial_ref", shape=(), dtype="int64", fill_value=0)
+        sref[...] = 0
+    sref.attrs.update(cf_attrs)
+
+    for name, arr in group.arrays():
+        if name != "spatial_ref" and {"y", "x"}.issubset(arr.metadata.dimension_names or ()):
+            arr.attrs["grid_mapping"] = "spatial_ref"
 
 
 def create_s1_store(
@@ -346,7 +335,6 @@ def create_s1_store(
     Returns the root group.
     """
     layout = compute_multiscales_layout(metadata.shape, metadata.spatial_transform)
-    tile_matrix_set = _create_tile_matrix_set(metadata.crs, metadata.bounds, layout)
 
     root = zarr.open_group(str(store_path), mode="w-", zarr_format=3)
     orbit_group = root.create_group(orbit_direction)
@@ -357,7 +345,6 @@ def create_s1_store(
             "multiscales": {
                 "layout": layout,
                 "resampling_method": "average",
-                "tile_matrix_set": tile_matrix_set,
             },
             "proj:code": metadata.crs,
             "spatial:dimensions": ["y", "x"],
@@ -404,6 +391,7 @@ def create_s1_store(
         _create_spatial_coordinate_arrays(
             level_group, level_h, level_w, level_entry["spatial:transform"]
         )
+        _add_grid_mapping(level_group, metadata.crs)
 
     # Coordinate variables at native resolution only
     r10m = orbit_group["r10m"]
@@ -586,6 +574,7 @@ def ingest_s1tiling_acquisition(
                 _create_spatial_coordinate_arrays(
                     level_group, level_h, level_w, level_entry["spatial:transform"]
                 )
+                _add_grid_mapping(level_group, meta.crs)
             r10m = orbit_group["r10m"]
             for name, dtype, fill in [
                 ("time", "int64", 0),
@@ -960,6 +949,8 @@ def ingest_s1tiling_conditions(
                 min=float(np.nanmin(data)),
                 max=float(np.nanmax(data)),
             )
+
+    _add_grid_mapping(conditions, ref_crs)
 
     log.info(
         "Conditions ingestion complete",

--- a/tests/test_s1_rtc_ingest.py
+++ b/tests/test_s1_rtc_ingest.py
@@ -234,6 +234,38 @@ class TestCreateStore:
         assert r10m["vv"].dtype == np.float32
         assert r10m["border_mask"].dtype == np.uint8
 
+    def test_no_tile_matrix_set(
+        self, s1_store_path: Path, sample_metadata: S1TilingMetadata
+    ) -> None:
+        # tile_matrix_set is not part of the S1 GRD RTC data model (confirmed with the
+        # data-model owner): the multiscales attribute must not carry one.
+        root = create_s1_store(s1_store_path, "ascending", sample_metadata)
+        ms = dict(root["ascending"].attrs)["multiscales"]
+        assert "tile_matrix_set" not in ms
+        assert "layout" in ms
+
+    def test_cf_grid_mapping_resolves_crs(
+        self, s1_store_path: Path, sample_metadata: S1TilingMetadata
+    ) -> None:
+        # Each resolution level carries a CF spatial_ref grid-mapping so rioxarray (and
+        # TiTiler's GeoZarr reader) can resolve the CRS -- the geozarr proj:code attr
+        # alone is not read by rioxarray.
+        import rioxarray  # noqa: F401  -- registers the .rio accessor
+
+        create_s1_store(s1_store_path, "ascending", sample_metadata)
+        r10m = zarr.open_group(str(s1_store_path), mode="r", zarr_format=3)["ascending"]["r10m"]
+        assert "spatial_ref" in list(r10m.array_keys())
+        assert dict(r10m["vv"].attrs).get("grid_mapping") == "spatial_ref"
+        assert dict(r10m["vh"].attrs).get("grid_mapping") == "spatial_ref"
+
+        ds = xr.open_zarr(
+            str(s1_store_path / "ascending" / "r10m"),
+            consolidated=False,
+            decode_coords="all",
+        )
+        assert ds.rio.crs is not None
+        assert ds.rio.crs.to_epsg() == 32633
+
     def test_coordinate_variables(
         self, s1_store_path: Path, sample_metadata: S1TilingMetadata
     ) -> None:
@@ -578,6 +610,9 @@ class TestIngestConditions:
         assert attrs["spatial:dimensions"] == ["y", "x"]
         assert len(attrs["spatial:transform"]) == 6
         assert attrs["spatial:shape"] == [SIZE, SIZE]
+        # CF grid-mapping so rioxarray can resolve the CRS of the condition arrays
+        assert "spatial_ref" in list(conditions.array_keys())
+        assert dict(conditions["gamma_area_037"].attrs).get("grid_mapping") == "spatial_ref"
 
     def test_gamma_area_array_shape_and_dtype(
         self, s1_store_with_acquisition: Path, gamma_area_geotiff: Path


### PR DESCRIPTION
## Why

Two related issues surfaced while bringing the S1 GRD RTC pipeline end-to-end through **titiler-eopf v0.5.0** (see data-pipeline `subissue_4_end_to_end.md`, issue I-7):

1. **Missing CF grid-mapping.** `create_s1_store` wrote only the GeoZarr `proj:code` attribute. rioxarray (and TiTiler's GeoZarr reader) resolve a group's CRS from a CF `spatial_ref`/`crs_wkt` coordinate, **not** `proj:code` — so `ds.rio.crs` was `None`, every multiscale group was rejected by the reader's `_validate_zarr`, and the reader built **zero** usable groups → HTTP 500 (`'tile_matrix_set'` / "not enough values to unpack") on `/info`, `/preview`, and tiles. The S2 converter already writes a `spatial_ref` grid-mapping; this brings S1 in line.

2. **`tile_matrix_set` should not be present.** Confirmed with the data-model owner that `tile_matrix_set` is not part of the S1 GRD RTC data model. The orbit-group `multiscales` no longer carries one. The `data_api` reader already treats it as optional (`MISSING` default), and the "new orbit in existing store" path never wrote it — so this also makes the two creation paths consistent.

## What

- Add `_add_grid_mapping(group, crs_string)` — builds the CF attributes from `pyproj.CRS.to_cf()` (the same source rioxarray uses, so the projection is described correctly for any CRS rather than hard-coded), creates a scalar `spatial_ref` coordinate, and sets `grid_mapping="spatial_ref"` on every `(y, x)` array. Called for each resolution level (both store-creation paths) and the `conditions` group.
- Remove `_create_tile_matrix_set()` and its `multiscales` entry (and the now-unused `rasterio.crs` import).
- Tests: assert `tile_matrix_set` is absent, that `spatial_ref` is present and `rio.crs` resolves to the native EPSG (`decode_coords="all"`), and that the conditions group carries `grid_mapping`.

## Downstream impact

This fixes **at the source** what `data-pipeline` currently works around in `ingest_v1_s1_rtc.py` (`_patch_cf_grid_mapping`, and the now-removed `_patch_tile_matrix_limits`). Once this lands and the pin is bumped, the pipeline patch can be dropped (already removed there).

## Verification

- `uv run pytest tests/test_s1_rtc_ingest.py tests/test_data_api/test_s1_rtc.py tests/test_s1_stac.py` → 67 passed
- Full suite green (exit 0)
- Verified locally: a store written by the patched `create_s1_store` opens with `decode_coords="all"` and `ds.rio.crs.to_epsg() == 32631`

🤖 Generated with [Claude Code](https://claude.com/claude-code)