### PR TITLE
fix(s1-ingest): discover multi-frame acquisitions with a masked timestamp (#183)

### DIFF
--- a/src/eopf_geozarr/conversion/s1_ingest.py
+++ b/src/eopf_geozarr/conversion/s1_ingest.py
@@ -55,13 +55,15 @@ OVERVIEW_CHAIN = [
 
 # S1Tiling filename pattern
 # e.g. s1a_32TQM_vv_ASC_037_20230115t061234_GammaNaughtRTC.tif
+# Multi-frame products mask the time as 'txxxxxx' (no single shared acquisition time); those are
+# accepted here and the real stamp is resolved from the GeoTIFF ACQUISITION_DATETIME tag (#183).
 S1TILING_FILENAME_PATTERN = re.compile(
     r"(?P<platform>s1[abc])_"
     r"(?P<tile>[0-9]{2}[A-Z]{3})_"
     r"(?P<pol>vv|vh)_"
     r"(?P<orbit_dir>ASC|DES)_"
     r"(?P<rel_orbit>\d{3})_"
-    r"(?P<acq_stamp>\d{8}t\d{6})_"
+    r"(?P<acq_stamp>\d{8}t(?:\d{6}|x{6}))_"
     r"(?P<product>GammaNaughtRTC)"
     r"(?P<mask>_BorderMask)?\.tif$"
 )
@@ -668,6 +670,17 @@ def consolidate_s1_store(store_path: str | Path, orbit_direction: str) -> None:
 # =============================================================================
 
 
+def _acq_stamp_from_geotiff(path: str | Path) -> str:
+    """Resolve a ``YYYYMMDDtHHMMSS`` acquisition stamp from a GeoTIFF's ACQUISITION_DATETIME tag.
+
+    Used when an S1Tiling filename carries a masked multi-frame time (e.g. ``…txxxxxx``), which
+    has no real timestamp to parse from the name. See #183.
+    """
+    iso = extract_geotiff_metadata(path).datetime  # e.g. "2023-01-15T06:12:34"
+    date_part, time_part = iso.split("T")
+    return f"{date_part.replace('-', '')}t{time_part.replace(':', '')}"
+
+
 def discover_s1tiling_acquisitions(input_dir: str | Path) -> list[dict]:
     """Discover and group S1Tiling GeoTIFF files into acquisition bundles.
 
@@ -685,12 +698,19 @@ def discover_s1tiling_acquisitions(input_dir: str | Path) -> list[dict]:
         if parsed is None:
             continue
 
+        acq_stamp = parsed["acq_stamp"]
+        if "x" in acq_stamp:
+            # Multi-frame product: the filename time is masked (…txxxxxx); resolve the real
+            # stamp from the GeoTIFF ACQUISITION_DATETIME tag so grouping + downstream STAC
+            # datetime are correct (#183).
+            acq_stamp = _acq_stamp_from_geotiff(f)
+
         key = (
             parsed["platform"],
             parsed["tile"],
             parsed["orbit_dir"],
             parsed["rel_orbit"],
-            parsed["acq_stamp"],
+            acq_stamp,
         )
 
         if key not in groups:
@@ -699,7 +719,7 @@ def discover_s1tiling_acquisitions(input_dir: str | Path) -> list[dict]:
                 "tile": parsed["tile"],
                 "orbit_dir": parsed["orbit_dir"],
                 "rel_orbit": parsed["rel_orbit"],
-                "acq_stamp": parsed["acq_stamp"],
+                "acq_stamp": acq_stamp,
             }
 
         pol = parsed["pol"]

--- a/tests/test_s1_rtc_ingest.py
+++ b/tests/test_s1_rtc_ingest.py
@@ -187,6 +187,16 @@ class TestParseFilename:
         assert result["pol"] == "vh"
         assert result["is_mask"] is True
 
+    def test_masked_multiframe_time_stamp(self) -> None:
+        """Multi-frame products carry a masked time (…txxxxxx); the parser must still match so
+        the file isn't skipped (the real stamp is resolved later from the tag). See #183."""
+        result = parse_s1tiling_filename(
+            "s1a_32TQM_vv_ASC_037_20230115txxxxxx_GammaNaughtRTC.tif"
+        )
+        assert result is not None
+        assert result["acq_stamp"] == "20230115txxxxxx"
+        assert result["pol"] == "vv"
+
     def test_returns_none_for_unknown(self) -> None:
         assert parse_s1tiling_filename("random_file.tif") is None
         assert parse_s1tiling_filename("not_a_geotiff.txt") is None
@@ -493,6 +503,27 @@ class TestDiscoverAcquisitions:
         _create_synthetic_geotiff(tmp_path / "random_file.tif", data, tags=ACQ1_TAGS)
         acqs = discover_s1tiling_acquisitions(tmp_path)
         assert len(acqs) == 0
+
+    def test_resolves_masked_multiframe_stamp_from_tag(self, tmp_path: Path) -> None:
+        """Multi-frame products whose filename time is masked (…txxxxxx) must still be discovered
+        as a complete acquisition, with acq_stamp resolved from the GeoTIFF ACQUISITION_DATETIME
+        tag rather than the filename. Regression for #183 (previously returned 0 acquisitions)."""
+        data = np.ones((SIZE, SIZE), dtype=np.float32)
+        mask = np.ones((SIZE, SIZE), dtype=np.uint8)
+        stamp = "20230115txxxxxx"  # masked multi-frame time
+        for pol in ("vv", "vh"):
+            base = f"s1a_32TQM_{pol}_ASC_037_{stamp}_GammaNaughtRTC"
+            _create_synthetic_geotiff(tmp_path / f"{base}.tif", data, tags=ACQ1_TAGS)
+            _create_synthetic_geotiff(tmp_path / f"{base}_BorderMask.tif", mask, tags=ACQ1_TAGS)
+
+        acqs = discover_s1tiling_acquisitions(tmp_path)
+
+        assert len(acqs) == 1
+        acq = acqs[0]
+        # ACQUISITION_DATETIME "2023:01:15T06:12:34Z" -> resolved stamp
+        assert acq["acq_stamp"] == "20230115t061234"
+        for k in ("vv", "vh", "vv_mask", "vh_mask"):
+            assert k in acq
 
 
 # =============================================================================


### PR DESCRIPTION
Closes #183.

## Problem
`discover_s1tiling_acquisitions` returned **0 acquisitions** for multi-frame S1Tiling products. Their GeoTIFF filenames mask the acquisition time as `…txxxxxx` (no single shared time across the merged frames), and the filename regex required `\d{8}t\d{6}`. So `parse_s1tiling_filename` returned `None`, every file was skipped, and discovery returned `[]` — silently, no error.

Surfaced by the 32TLR S1 RTC e2e (data-pipeline #226, item F1). data-pipeline shipped a temporary workaround (#237) that renamed `…txxxxxx` products from the `ACQUISITION_DATETIME` tag before discovery; this is the durable upstream fix that lets that workaround be retired.

## Fix
- **Relax the regex** `acq_stamp` group to accept a masked time: `\d{8}t(?:\d{6}|x{6})` — masked files are no longer dropped.
- **Resolve the real stamp in discovery**: when the parsed stamp is masked, derive the true `YYYYMMDDtHHMMSS` from the GeoTIFF `ACQUISITION_DATETIME` tag (reusing `extract_geotiff_metadata`) and use it for the grouping key + downstream STAC `datetime`.

`parse_s1tiling_filename` stays pure (regex only); the tag I/O lives in `discover`, which already has the file path — and only runs for masked files, so the common single-frame path is unchanged.

## Tests (TDD)
- `test_masked_multiframe_time_stamp` — the parser now matches a `…txxxxxx` filename.
- `test_resolves_masked_multiframe_stamp_from_tag` — a masked-stamp bundle (real synthetic GeoTIFFs + `ACQUISITION_DATETIME` tag) is discovered as a complete acquisition with `acq_stamp` resolved from the tag.
- Full `tests/test_s1_rtc_ingest.py`: **46 passed**, no regressions.

## Follow-up
Once this lands, the data-pipeline #237 normalization workaround can be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)