### PR TITLE
fix(s1-rtc): CF-encode `time` at every level for datetime-based rendering

### DIFF
--- a/src/eopf_geozarr/conversion/s1_ingest.py
+++ b/src/eopf_geozarr/conversion/s1_ingest.py
@@ -297,6 +297,37 @@ def _create_spatial_coordinate_arrays(
     )
 
 
+# CF datetime encoding for the `time` coordinate. Without it the array is a bare int64 and readers
+# (xarray / TiTiler's `open_datatree(decode_times=True)`) cannot expose `time` as a datetime index, so
+# per-acquisition previews can only select positionally (`sel=time={index}`) — fragile once a cube's
+# time axis goes non-monotonic. With these attrs `time` decodes to datetime64 and previews can render by
+# `sel=time={datetime}` (order-immune). The stored dtype stays int64 nanoseconds. See data-model #192.
+TIME_CF_ATTRS = {
+    "units": "nanoseconds since 1970-01-01",
+    "calendar": "proleptic_gregorian",
+    "standard_name": "time",
+}
+
+
+def _create_time_coordinate_array(level_group: zarr.Group) -> None:
+    """Create the CF-encoded ``time`` coordinate (length 0, grown on append) on one level group.
+
+    Replicated at EVERY multiscale level (with identical values) so datetime ``.sel`` resolves at
+    whatever level a reader renders — TiTiler picks a coarse level for previews, and a level lacking a
+    ``time`` coordinate cannot be selected by datetime. Keeping the dtype/values consistent across
+    levels is also required for the datatree to open (mixed int64/datetime64 fails alignment).
+    """
+    t_arr = level_group.create_array(
+        "time",
+        shape=(0,),
+        dtype="int64",
+        chunks=(512,),
+        fill_value=0,
+        dimension_names=["time"],
+    )
+    t_arr.attrs.update({**TIME_CF_ATTRS, "_ARRAY_DIMENSIONS": ["time"]})
+
+
 def _add_grid_mapping(group: zarr.Group, crs_string: str) -> None:
     """Add a CF ``spatial_ref`` grid-mapping coordinate to a group holding (y, x) arrays.
 
@@ -394,11 +425,12 @@ def create_s1_store(
             level_group, level_h, level_w, level_entry["spatial:transform"]
         )
         _add_grid_mapping(level_group, metadata.crs)
+        # `time` coordinate on every level so datetime `.sel` resolves at any rendered scale (#192).
+        _create_time_coordinate_array(level_group)
 
-    # Coordinate variables at native resolution only
+    # Per-time metadata coordinates at native resolution only (not selected on by readers).
     r10m = orbit_group["r10m"]
     for name, dtype, fill in [
-        ("time", "int64", 0),
         ("absolute_orbit", "int32", 0),
         ("relative_orbit", "int32", 0),
     ]:
@@ -577,9 +609,10 @@ def ingest_s1tiling_acquisition(
                     level_group, level_h, level_w, level_entry["spatial:transform"]
                 )
                 _add_grid_mapping(level_group, meta.crs)
+                # `time` coordinate on every level (datetime `.sel` at any scale, #192).
+                _create_time_coordinate_array(level_group)
             r10m = orbit_group["r10m"]
             for name, dtype, fill in [
-                ("time", "int64", 0),
                 ("absolute_orbit", "int32", 0),
                 ("relative_orbit", "int32", 0),
             ]:
@@ -649,7 +682,10 @@ def ingest_s1tiling_acquisition(
 
     log.info("Overviews generated", levels=len(data_by_level))
 
-    # Write data at all levels
+    dt_ns = np.datetime64(meta.datetime).astype("datetime64[ns]").astype(np.int64)
+
+    # Write data + the `time` coordinate at all levels (time is replicated per level so datetime
+    # `.sel` resolves at any rendered scale, #192).
     for level_name, (vv_lev, vh_lev, mask_lev) in data_by_level.items():
         level = orbit[level_name]
         h, w = vv_lev.shape
@@ -662,12 +698,12 @@ def ingest_s1tiling_acquisition(
         level["vh"][current_size, :, :] = vh_lev
         level["border_mask"][current_size, :, :] = mask_lev
 
-    # Append coordinate variables
-    for coord_name in ["time", "absolute_orbit", "relative_orbit", "platform"]:
-        r10m[coord_name].resize((new_size,))
+        level["time"].resize((new_size,))
+        level["time"][current_size] = dt_ns
 
-    dt_ns = np.datetime64(meta.datetime).astype("datetime64[ns]").astype(np.int64)
-    r10m["time"][current_size] = dt_ns
+    # Per-time metadata coordinates at native resolution only.
+    for coord_name in ["absolute_orbit", "relative_orbit", "platform"]:
+        r10m[coord_name].resize((new_size,))
     r10m["absolute_orbit"][current_size] = meta.absolute_orbit
     r10m["relative_orbit"][current_size] = meta.relative_orbit
     r10m["platform"][current_size] = meta.platform

--- a/tests/test_s1_rtc_ingest.py
+++ b/tests/test_s1_rtc_ingest.py
@@ -847,3 +847,98 @@ class TestDiscoverConditions:
         assert len(conditions) == 1
         assert conditions[0]["tile"] == "32TQM"
         assert conditions[0]["orbit"] == "037"
+
+
+# =============================================================================
+# CF datetime `time` coordinate — render-by-datetime support (data-model #192)
+# =============================================================================
+
+_LEVELS = ["r10m", "r20m", "r60m", "r120m", "r360m", "r720m"]
+
+
+class TestTimeCFDatetime:
+    """`time` is CF-encoded at every multiscale level so readers decode it to datetime64 and can
+    select a slice by datetime (`sel=time={datetime}`) at any rendered scale, even on a non-monotonic
+    axis. This replaces the fragile positional `sel=time={index}` rendering (#192)."""
+
+    def _paths(self, geotiff_dir: Path, stamp: str) -> tuple[Path, Path, Path]:
+        vv = geotiff_dir / f"s1a_32TQM_vv_ASC_037_{stamp}_GammaNaughtRTC.tif"
+        vh = geotiff_dir / f"s1a_32TQM_vh_ASC_037_{stamp}_GammaNaughtRTC.tif"
+        mask = geotiff_dir / f"s1a_32TQM_vv_ASC_037_{stamp}_GammaNaughtRTC_BorderMask.tif"
+        return vv, vh, mask
+
+    def test_time_has_cf_attrs_at_every_level(
+        self, s1_geotiff_dir: Path, s1_store_path: Path
+    ) -> None:
+        vv, vh, mask = self._paths(s1_geotiff_dir, "20230115t061234")
+        ingest_s1tiling_acquisition(vv, vh, mask, s1_store_path, "ascending")
+        root = zarr.open_group(str(s1_store_path), mode="r", zarr_format=3)
+        for level in _LEVELS:
+            attrs = dict(root["ascending"][level]["time"].attrs)
+            assert attrs.get("units") == "nanoseconds since 1970-01-01", level
+            assert attrs.get("calendar") == "proleptic_gregorian", level
+            assert attrs.get("standard_name") == "time", level
+
+    def test_open_datatree_decodes_time_to_datetime64(
+        self, s1_geotiff_dir: Path, s1_store_path: Path
+    ) -> None:
+        vv, vh, mask = self._paths(s1_geotiff_dir, "20230115t061234")
+        ingest_s1tiling_acquisition(vv, vh, mask, s1_store_path, "ascending")
+        dt = xr.open_datatree(
+            str(s1_store_path), engine="zarr", decode_times=True, consolidated=False
+        )
+        for level in ("r10m", "r720m"):
+            da = dt["ascending"][level]["vv"]
+            assert "time" in da.coords, level
+            assert np.issubdtype(da["time"].dtype, np.datetime64), level
+
+    def test_exact_datetime_sel_on_nonmonotonic_axis(
+        self, s1_geotiff_dir: Path, s1_store_path: Path
+    ) -> None:
+        """Ingest LATER acq first then EARLIER → non-monotonic axis; exact datetime `.sel` still
+        returns the right physical slice at both the native and a coarse level (the 31TEH case)."""
+        vv2, vh2, mask2 = self._paths(s1_geotiff_dir, "20230127t061235")  # 2023-01-27 (later)
+        vv1, vh1, mask1 = self._paths(s1_geotiff_dir, "20230115t061234")  # 2023-01-15 (earlier)
+        ingest_s1tiling_acquisition(vv2, vh2, mask2, s1_store_path, "ascending")  # -> index 0
+        ingest_s1tiling_acquisition(vv1, vh1, mask1, s1_store_path, "ascending")  # -> index 1
+
+        dt = xr.open_datatree(
+            str(s1_store_path), engine="zarr", decode_times=True, consolidated=False
+        )
+        times = dt["ascending"]["r10m"]["time"].values
+        assert times[0] > times[1], "axis should be non-monotonic (later acq appended first)"
+
+        early = np.datetime64("2023-01-15T06:12:34")  # physical index 1
+        later = np.datetime64("2023-01-27T06:12:35")  # physical index 0
+        for level in ("r10m", "r720m"):
+            vvda = dt["ascending"][level]["vv"]
+            np.testing.assert_array_equal(
+                vvda.sel(time=early).values, vvda.isel(time=1).values, err_msg=f"{level} early"
+            )
+            np.testing.assert_array_equal(
+                vvda.sel(time=later).values, vvda.isel(time=0).values, err_msg=f"{level} later"
+            )
+
+    def test_time_values_identical_across_levels(
+        self, s1_geotiff_dir: Path, s1_store_path: Path
+    ) -> None:
+        vv1, vh1, mask1 = self._paths(s1_geotiff_dir, "20230115t061234")
+        vv2, vh2, mask2 = self._paths(s1_geotiff_dir, "20230127t061235")
+        ingest_s1tiling_acquisition(vv1, vh1, mask1, s1_store_path, "ascending")
+        ingest_s1tiling_acquisition(vv2, vh2, mask2, s1_store_path, "ascending")
+        root = zarr.open_group(str(s1_store_path), mode="r", zarr_format=3)
+        ref = np.asarray(root["ascending"]["r10m"]["time"][:])
+        assert ref.shape == (2,)
+        for level in _LEVELS[1:]:
+            np.testing.assert_array_equal(np.asarray(root["ascending"][level]["time"][:]), ref)
+
+    def test_r10m_time_still_int64_for_register(
+        self, s1_geotiff_dir: Path, s1_store_path: Path
+    ) -> None:
+        """register_per_acquisition reads r10m/time as raw int64 ns — CF attrs must not change that."""
+        vv, vh, mask = self._paths(s1_geotiff_dir, "20230115t061234")
+        ingest_s1tiling_acquisition(vv, vh, mask, s1_store_path, "ascending")
+        root = zarr.open_group(str(s1_store_path), mode="r", zarr_format=3)
+        arr = root["ascending"]["r10m"]["time"]
+        assert arr.dtype == np.dtype("int64")
+        assert str(np.datetime64(int(arr[0]), "ns")).startswith("2023-01-15")


### PR DESCRIPTION
Fixes the root cause behind broken/fragile S1 RTC per-acquisition previews. Tracking issue: EOPF-Explorer/data-model#192.

## Problem
Per-acquisition previews render via titiler `sel=time={INTEGER index}`. Cubes go **non-monotonic** because `ingest_s1tiling_acquisition` always appends at the physical end (a cross-run append of an earlier-dated scene puts the axis out of order — proved on 31TEH: `[06-08, 06-07]`, and the 06-07 item has no preview). Keeping positional indices correct would need cube reorder + full re-registration on every append — not scalable.

## Fix — render by datetime
Deployed titiler (v0.5.0) already does label `da.sel(…, method=…)` via `open_datatree(decode_times=True)`. The only gap is that the cube's `time` array is a bare int64 with **no CF datetime metadata**, so it can't be a datetime index. Encoding it lets previews select by **exact datetime**, which works **even on a non-monotonic axis** — no reorder, register only the new item.

titiler picks a multiscale level by zoom (previews use a **coarse** level), so `time` must resolve there. Orbit-level inheritance fails to open while r10m stays bare int64 (`AlignmentError`: int64 vs datetime64 on the shared dim). So `time` is CF-encoded consistently **at every level**:
- new `_create_time_coordinate_array` + `TIME_CF_ATTRS` (`units`/`calendar`/`standard_name`); created at every level in the create + append-group paths.
- the append write resizes/writes `time` at every level (was r10m only).
- `absolute_orbit`/`relative_orbit`/`platform` stay at r10m (not selected on).
- stored dtype stays int64 ns → `register_per_acquisition`'s raw read is unaffected.

## Tests
`TestTimeCFDatetime` (5 tests), incl. `test_exact_datetime_sel_on_nonmonotonic_axis` selecting the right slice at the native AND a coarse level on a non-monotonic axis. **55 passed** (50 existing + 5).

Validated locally against titiler's exact opener; live end-to-end validation tracked in #192.

🤖 Generated with [Claude Code](https://claude.com/claude-code)