### PR TITLE
fix(s1-rtc): write CF `_FillValue` on float arrays (#172 parity)

### DIFF
--- a/src/eopf_geozarr/conversion/s1_ingest.py
+++ b/src/eopf_geozarr/conversion/s1_ingest.py
@@ -26,6 +26,7 @@ import structlog
 import zarr
 import zarr.codecs
 from pyproj import CRS as PyprojCRS
+from xarray.backends.zarr import FillValueCoder
 from zarr_cm import geo_proj
 from zarr_cm import multiscales as multiscales_cm
 from zarr_cm import spatial as spatial_cm
@@ -308,6 +309,21 @@ TIME_CF_ATTRS = {
     "standard_name": "time",
 }
 
+# CF `_FillValue` for the float32 arrays, mirroring the S1 GRD converter (geozarr.py)
+# and S2 (data-model #172). This is what lets xarray mask NaN nodata via
+# `use_zarr_fill_value_as_mask=True` despite xarray #11345 — the zarr-level `fill_value`
+# field alone is not surfaced through xarray's encoding. We encode it with
+# `FillValueCoder` so the stored attribute matches the base64 form S2 writes
+# (`AAAAAAAA+H8=`). The S2 path gets this for free via `to_zarr`; this store is written
+# zarr-direct, so the attribute must be set explicitly.
+FLOAT32_NAN_FILL_VALUE = FillValueCoder.encode(np.nan, np.dtype("float32"))
+# CF metadata for the backscatter bands (vv/vh).
+BACKSCATTER_CF_ATTRS = {
+    "standard_name": "surface_backwards_scattering_coefficient_of_radar_wave",
+    "units": "1",
+    "_FillValue": FLOAT32_NAN_FILL_VALUE,
+}
+
 
 def _create_time_coordinate_array(level_group: zarr.Group) -> None:
     """Create the CF-encoded ``time`` coordinate (length 0, grown on append) on one level group.
@@ -358,6 +374,40 @@ def _add_grid_mapping(group: zarr.Group, crs_string: str) -> None:
             arr.attrs["grid_mapping"] = "spatial_ref"
 
 
+def _create_band_arrays(level_group: zarr.Group, level_h: int, level_w: int) -> None:
+    """Create the (time, y, x) data bands (vv, vh, border_mask) for one multiscale level.
+
+    Float backscatter bands (vv/vh) get the CF ``_FillValue``/``standard_name``/``units``
+    attributes so readers can mask NaN nodata (xarray #11345) — parity with the S1 GRD
+    converter and S2 (data-model #172). Shared by ``create_s1_store`` (new store) and
+    ``ingest_s1tiling_acquisition`` (new orbit added to an existing store) so the two
+    creation paths cannot drift.
+    """
+    inner_chunks = (
+        1,
+        calculate_aligned_chunk_size(level_h, 512),
+        calculate_aligned_chunk_size(level_w, 512),
+    )
+    shard_shape = (1, level_h, level_w)
+    for name, dtype, fill in [
+        ("vv", "float32", float("nan")),
+        ("vh", "float32", float("nan")),
+        ("border_mask", "uint8", 0),
+    ]:
+        band = level_group.create_array(
+            name,
+            shape=(0, level_h, level_w),
+            dtype=dtype,
+            chunks=inner_chunks,
+            shards=shard_shape,
+            compressors=zarr.codecs.BloscCodec(cname="zstd", clevel=5),
+            fill_value=fill,
+            dimension_names=["time", "y", "x"],
+        )
+        if name in ("vv", "vh"):
+            band.attrs.update(BACKSCATTER_CF_ATTRS)
+
+
 def create_s1_store(
     store_path: str | Path,
     orbit_direction: str,
@@ -398,28 +448,7 @@ def create_s1_store(
             }
         )
 
-        inner_chunks = (
-            1,
-            calculate_aligned_chunk_size(level_h, 512),
-            calculate_aligned_chunk_size(level_w, 512),
-        )
-        shard_shape = (1, level_h, level_w)
-
-        for name, dtype, fill in [
-            ("vv", "float32", float("nan")),
-            ("vh", "float32", float("nan")),
-            ("border_mask", "uint8", 0),
-        ]:
-            level_group.create_array(
-                name,
-                shape=(0, level_h, level_w),
-                dtype=dtype,
-                chunks=inner_chunks,
-                shards=shard_shape,
-                compressors=zarr.codecs.BloscCodec(cname="zstd", clevel=5),
-                fill_value=fill,
-                dimension_names=["time", "y", "x"],
-            )
+        _create_band_arrays(level_group, level_h, level_w)
 
         _create_spatial_coordinate_arrays(
             level_group, level_h, level_w, level_entry["spatial:transform"]
@@ -584,27 +613,7 @@ def ingest_s1tiling_acquisition(
                         "spatial:transform": level_entry["spatial:transform"],
                     }
                 )
-                inner_chunks = (
-                    1,
-                    calculate_aligned_chunk_size(level_h, 512),
-                    calculate_aligned_chunk_size(level_w, 512),
-                )
-                shard_shape = (1, level_h, level_w)
-                for name, dtype, fill in [
-                    ("vv", "float32", float("nan")),
-                    ("vh", "float32", float("nan")),
-                    ("border_mask", "uint8", 0),
-                ]:
-                    level_group.create_array(
-                        name,
-                        shape=(0, level_h, level_w),
-                        dtype=dtype,
-                        chunks=inner_chunks,
-                        shards=shard_shape,
-                        compressors=zarr.codecs.BloscCodec(cname="zstd", clevel=5),
-                        fill_value=fill,
-                        dimension_names=["time", "y", "x"],
-                    )
+                _create_band_arrays(level_group, level_h, level_w)
                 _create_spatial_coordinate_arrays(
                     level_group, level_h, level_w, level_entry["spatial:transform"]
                 )
@@ -1035,6 +1044,8 @@ def ingest_s1tiling_conditions(
                 fill_value=float("nan"),
                 dimension_names=["y", "x"],
             )
+            # CF `_FillValue` so readers mask NaN nodata (xarray #11345), like vv/vh (#172).
+            arr.attrs["_FillValue"] = FLOAT32_NAN_FILL_VALUE
             arr[:, :] = data
             log.info(
                 "Wrote condition array",

--- a/src/eopf_geozarr/conversion/s1_ingest.py
+++ b/src/eopf_geozarr/conversion/s1_ingest.py
@@ -19,6 +19,7 @@ import re
 from dataclasses import dataclass
 from math import ceil
 from pathlib import Path
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 import rasterio
@@ -26,12 +27,19 @@ import structlog
 import zarr
 import zarr.codecs
 from pyproj import CRS as PyprojCRS
+
+# `FillValueCoder` is xarray's internal CF fill-value encoder: the canonical way to produce
+# the base64 `_FillValue` xarray reads back under `use_zarr_fill_value_as_mask` (xarray
+# #11345); the S2 path relies on the same mechanism. Internal API — revisit if xarray moves it.
 from xarray.backends.zarr import FillValueCoder
 from zarr_cm import geo_proj
 from zarr_cm import multiscales as multiscales_cm
 from zarr_cm import spatial as spatial_cm
 
 from eopf_geozarr.conversion.utils import calculate_aligned_chunk_size
+
+if TYPE_CHECKING:
+    from eopf_geozarr.data_api.geozarr.types import S1BackscatterAttrsJSON
 
 log = structlog.get_logger()
 
@@ -318,7 +326,7 @@ TIME_CF_ATTRS = {
 # zarr-direct, so the attribute must be set explicitly.
 FLOAT32_NAN_FILL_VALUE = FillValueCoder.encode(np.nan, np.dtype("float32"))
 # CF metadata for the backscatter bands (vv/vh).
-BACKSCATTER_CF_ATTRS = {
+BACKSCATTER_CF_ATTRS: S1BackscatterAttrsJSON = {
     "standard_name": "surface_backwards_scattering_coefficient_of_radar_wave",
     "units": "1",
     "_FillValue": FLOAT32_NAN_FILL_VALUE,
@@ -405,23 +413,24 @@ def _create_band_arrays(level_group: zarr.Group, level_h: int, level_w: int) -> 
             dimension_names=["time", "y", "x"],
         )
         if name in ("vv", "vh"):
-            band.attrs.update(BACKSCATTER_CF_ATTRS)
+            # cast: zarr's `attrs.update` is typed for its JSON union, which a TypedDict
+            # (invariant) doesn't satisfy structurally; the values are JSON-safe.
+            band.attrs.update(cast("dict", BACKSCATTER_CF_ATTRS))
 
 
-def create_s1_store(
-    store_path: str | Path,
-    orbit_direction: str,
-    metadata: S1TilingMetadata,
+def _build_orbit_group(
+    root: zarr.Group, orbit_direction: str, metadata: S1TilingMetadata
 ) -> zarr.Group:
-    """Create a new S1 GRD RTC Zarr V3 store with full conventions metadata.
+    """Create one orbit group (asc/desc) with full GeoZarr metadata.
 
-    Returns the root group.
+    Builds the multiscale level groups (bands + spatial coordinates + grid-mapping +
+    per-level ``time``) and the native-resolution per-acquisition metadata coordinates.
+    Shared by ``create_s1_store`` (new store) and ``ingest_s1tiling_acquisition`` (new
+    orbit added to an existing store) so the two creation paths cannot drift — the inline
+    path previously omitted ``proj:code`` on level groups.
     """
     layout = compute_multiscales_layout(metadata.shape, metadata.spatial_transform)
-
-    root = zarr.open_group(str(store_path), mode="w-", zarr_format=3)
     orbit_group = root.create_group(orbit_direction)
-
     orbit_group.attrs.update(
         {
             "zarr_conventions": ZARR_CONVENTIONS,
@@ -479,6 +488,20 @@ def create_s1_store(
         fill_value="",
         dimension_names=["time"],
     )
+    return orbit_group
+
+
+def create_s1_store(
+    store_path: str | Path,
+    orbit_direction: str,
+    metadata: S1TilingMetadata,
+) -> zarr.Group:
+    """Create a new S1 GRD RTC Zarr V3 store with full conventions metadata.
+
+    Returns the root group.
+    """
+    root = zarr.open_group(str(store_path), mode="w-", zarr_format=3)
+    _build_orbit_group(root, orbit_direction, metadata)
 
     log.info(
         "Created S1 store",
@@ -588,59 +611,9 @@ def ingest_s1tiling_acquisition(
     else:
         root = zarr.open_group(str(store_path), mode="r+", zarr_format=3)
         if orbit_direction not in root:
-            # Create orbit direction group in existing store
-            orbit_group = root.create_group(orbit_direction)
-            layout = compute_multiscales_layout(meta.shape, meta.spatial_transform)
-            orbit_group.attrs.update(
-                {
-                    "zarr_conventions": ZARR_CONVENTIONS,
-                    "multiscales": {
-                        "layout": layout,
-                        "resampling_method": "average",
-                    },
-                    "proj:code": meta.crs,
-                    "spatial:dimensions": ["y", "x"],
-                    "spatial:bbox": meta.bounds,
-                }
-            )
-            for level_entry in layout:
-                level_name = level_entry["asset"]
-                level_h, level_w = level_entry["spatial:shape"]
-                level_group = orbit_group.create_group(level_name)
-                level_group.attrs.update(
-                    {
-                        "spatial:shape": [level_h, level_w],
-                        "spatial:transform": level_entry["spatial:transform"],
-                    }
-                )
-                _create_band_arrays(level_group, level_h, level_w)
-                _create_spatial_coordinate_arrays(
-                    level_group, level_h, level_w, level_entry["spatial:transform"]
-                )
-                _add_grid_mapping(level_group, meta.crs)
-                # `time` coordinate on every level (datetime `.sel` at any scale, #192).
-                _create_time_coordinate_array(level_group)
-            r10m = orbit_group["r10m"]
-            for name, dtype, fill in [
-                ("absolute_orbit", "int32", 0),
-                ("relative_orbit", "int32", 0),
-            ]:
-                r10m.create_array(
-                    name,
-                    shape=(0,),
-                    dtype=dtype,
-                    chunks=(512,),
-                    fill_value=fill,
-                    dimension_names=["time"],
-                )
-            r10m.create_array(
-                "platform",
-                shape=(0,),
-                dtype="<U4",
-                chunks=(512,),
-                fill_value="",
-                dimension_names=["time"],
-            )
+            # Create the new orbit group in the existing store (same builder as a fresh
+            # store, so per-level metadata — incl. `proj:code` — stays consistent).
+            _build_orbit_group(root, orbit_direction, meta)
         else:
             # Validate consistency on append
             orbit_group = root[orbit_direction]

--- a/src/eopf_geozarr/data_api/geozarr/types.py
+++ b/src/eopf_geozarr/data_api/geozarr/types.py
@@ -60,6 +60,18 @@ class StandardYCoordAttrsJSON(TypedDict):
     _ARRAY_DIMENSIONS: list[Literal["y"]]
 
 
+class S1BackscatterAttrsJSON(TypedDict):
+    """CF attributes for the Sentinel-1 RTC backscatter bands (vv/vh).
+
+    ``_FillValue`` is the ``FillValueCoder``-encoded base64 NaN that lets xarray mask
+    nodata under ``use_zarr_fill_value_as_mask`` despite xarray #11345 (data-model #172).
+    """
+
+    standard_name: Literal["surface_backwards_scattering_coefficient_of_radar_wave"]
+    units: Literal["1"]
+    _FillValue: str
+
+
 class TileMatrixJSON(TypedDict):
     id: str
     scaleDenominator: float

--- a/tests/test_s1_rtc_ingest.py
+++ b/tests/test_s1_rtc_ingest.py
@@ -246,6 +246,34 @@ class TestCreateStore:
         assert r10m["vv"].dtype == np.float32
         assert r10m["border_mask"].dtype == np.uint8
 
+    def test_float_bands_declare_cf_fill_value(
+        self, s1_store_path: Path, sample_metadata: S1TilingMetadata
+    ) -> None:
+        """Float backscatter bands must declare a CF ``_FillValue`` attribute at
+        *every* multiscale level, matching S2 (data-model #172 / xarray #11345).
+
+        The zarr-level ``fill_value`` alone is not surfaced by xarray's encoding,
+        so ``to_masked_array()`` / ``use_zarr_fill_value_as_mask=True`` cannot mask
+        NaN nodata without the attribute. ``test_array_attrs`` only guards the S2
+        ``/measurements/`` layout, so the S1 RTC layout was previously unchecked.
+        """
+        from xarray.backends.zarr import FillValueCoder
+
+        root = create_s1_store(s1_store_path, "ascending", sample_metadata)
+        orbit = root["ascending"]
+        expected = FillValueCoder.encode(np.nan, np.dtype("float32"))
+        for level_name, _, _ in OVERVIEW_CHAIN:
+            for band in ("vv", "vh"):
+                attrs = dict(orbit[level_name][band].attrs)
+                assert attrs.get("_FillValue") == expected, (
+                    f"{level_name}/{band} missing/!= CF _FillValue"
+                )
+                assert (
+                    attrs.get("standard_name")
+                    == "surface_backwards_scattering_coefficient_of_radar_wave"
+                )
+                assert attrs.get("units") == "1"
+
     def test_no_tile_matrix_set(
         self, s1_store_path: Path, sample_metadata: S1TilingMetadata
     ) -> None:
@@ -353,6 +381,32 @@ class TestIngestAcquisition:
         assert idx == 1
         root = zarr.open_group(str(s1_store_path), mode="r", zarr_format=3)
         assert root["ascending"]["r10m"]["vv"].shape[0] == 2
+
+    def test_ingested_bands_declare_cf_fill_value(
+        self, s1_geotiff_dir: Path, s1_store_path: Path
+    ) -> None:
+        """End-to-end (production path): vv/vh carry CF ``_FillValue``/``standard_name``/
+        ``units`` at every level for BOTH the store-creating orbit (``create_s1_store``)
+        and a second orbit added via the inline new-orbit path — the two paths that were
+        previously inconsistent. Parity with S2 / S1 GRD (#172; xarray #11345).
+        """
+        from xarray.backends.zarr import FillValueCoder
+
+        vv, vh, mask = self._get_acq_paths(s1_geotiff_dir, "20230115t061234")
+        ingest_s1tiling_acquisition(vv, vh, mask, s1_store_path, "ascending")  # create_s1_store
+        ingest_s1tiling_acquisition(vv, vh, mask, s1_store_path, "descending")  # inline new orbit
+        expected = FillValueCoder.encode(np.nan, np.dtype("float32"))
+        root = zarr.open_group(str(s1_store_path), mode="r", zarr_format=3)
+        for orbit in ("ascending", "descending"):
+            for level_name, _, _ in OVERVIEW_CHAIN:
+                for band in ("vv", "vh"):
+                    attrs = dict(root[orbit][level_name][band].attrs)
+                    assert attrs.get("_FillValue") == expected, f"{orbit}/{level_name}/{band}"
+                    assert (
+                        attrs.get("standard_name")
+                        == "surface_backwards_scattering_coefficient_of_radar_wave"
+                    )
+                    assert attrs.get("units") == "1"
 
     def test_preserves_data_integrity(self, s1_geotiff_dir: Path, s1_store_path: Path) -> None:
         vv, vh, mask = self._get_acq_paths(s1_geotiff_dir, "20230115t061234")
@@ -678,6 +732,30 @@ class TestIngestConditions:
         root = zarr.open_group(str(s1_store_with_acquisition), mode="r", zarr_format=3)
         actual = root["ascending"]["conditions"]["gamma_area_037"][:]
         np.testing.assert_allclose(actual, expected, rtol=1e-6)
+
+    def test_float_conditions_declare_cf_fill_value(
+        self,
+        s1_store_with_acquisition: Path,
+        gamma_area_geotiff: Path,
+        lia_geotiff: Path,
+    ) -> None:
+        """Float condition arrays (gamma_area, lia) must declare a CF ``_FillValue`` so
+        readers mask NaN nodata (xarray #11345), like vv/vh (#172)."""
+        from xarray.backends.zarr import FillValueCoder
+
+        ingest_s1tiling_conditions(
+            store_path=s1_store_with_acquisition,
+            orbit_direction="ascending",
+            relative_orbit=37,
+            gamma_area_path=gamma_area_geotiff,
+            lia_path=lia_geotiff,
+        )
+        expected = FillValueCoder.encode(np.nan, np.dtype("float32"))
+        conditions = zarr.open_group(str(s1_store_with_acquisition), mode="r", zarr_format=3)[
+            "ascending"
+        ]["conditions"]
+        for arr_name in ("gamma_area_037", "lia_037"):
+            assert dict(conditions[arr_name].attrs).get("_FillValue") == expected, arr_name
 
     def test_gamma_area_is_sharded(
         self, s1_store_with_acquisition: Path, gamma_area_geotiff: Path

--- a/tests/test_s1_rtc_ingest.py
+++ b/tests/test_s1_rtc_ingest.py
@@ -408,6 +408,57 @@ class TestIngestAcquisition:
                     )
                     assert attrs.get("units") == "1"
 
+    def test_new_orbit_level_groups_carry_proj_code(
+        self, s1_geotiff_dir: Path, s1_store_path: Path
+    ) -> None:
+        """A second orbit added to an existing store must get the same per-level metadata
+        as the store-creating orbit — incl. ``proj:code`` on every level group. The inline
+        new-orbit path previously omitted it (drift vs ``create_s1_store``)."""
+        vv, vh, mask = self._get_acq_paths(s1_geotiff_dir, "20230115t061234")
+        ingest_s1tiling_acquisition(vv, vh, mask, s1_store_path, "ascending")
+        ingest_s1tiling_acquisition(vv, vh, mask, s1_store_path, "descending")
+        root = zarr.open_group(str(s1_store_path), mode="r", zarr_format=3)
+        for orbit in ("ascending", "descending"):
+            for level_name, _, _ in OVERVIEW_CHAIN:
+                attrs = dict(root[orbit][level_name].attrs)
+                assert attrs.get("proj:code") == CRS, f"{orbit}/{level_name} missing proj:code"
+
+    def test_fill_value_masking_roundtrip(self, tmp_path: Path, s1_store_path: Path) -> None:
+        """End-to-end: NaN nodata in vv comes back masked when the cube is reopened with
+        ``use_zarr_fill_value_as_mask=True`` — the behaviour the CF ``_FillValue`` attribute
+        exists to enable despite xarray #11345. Mirrors the S2 guarantee in
+        ``tests/test_array_attrs.py::test_fill_value_masking_roundtrip``.
+        """
+        stamp = "20230115t061234"
+        rng = np.random.default_rng(0)
+        vv_data = rng.uniform(0.0, 1.0, (SIZE, SIZE)).astype(np.float32)
+        vv_data[0:16, 0:16] = np.nan  # nodata patch
+        vh_data = rng.uniform(0.0, 0.5, (SIZE, SIZE)).astype(np.float32)
+        mask_data = np.ones((SIZE, SIZE), dtype=np.uint8)
+        vv = tmp_path / f"s1a_32TQM_vv_ASC_037_{stamp}_GammaNaughtRTC.tif"
+        vh = tmp_path / f"s1a_32TQM_vh_ASC_037_{stamp}_GammaNaughtRTC.tif"
+        mask = tmp_path / f"s1a_32TQM_vv_ASC_037_{stamp}_GammaNaughtRTC_BorderMask.tif"
+        _create_synthetic_geotiff(vv, vv_data, tags=ACQ1_TAGS)
+        _create_synthetic_geotiff(vh, vh_data, tags=ACQ1_TAGS)
+        _create_synthetic_geotiff(mask, mask_data, tags=ACQ1_TAGS)
+        ingest_s1tiling_acquisition(vv, vh, mask, s1_store_path, "ascending")
+
+        ds = xr.open_dataset(
+            str(s1_store_path / "ascending" / "r10m"),
+            engine="zarr",
+            consolidated=False,
+            decode_times=False,
+            decode_coords=False,
+            use_zarr_fill_value_as_mask=True,
+        )
+        try:
+            masked = ds["vv"].to_masked_array()
+            assert np.ma.is_masked(masked), "NaN nodata must be masked via `_FillValue`"
+            assert masked.mask[0, 0, 0], "nodata cell must be masked"
+            assert not masked.mask[0, -1, -1], "valid cell must not be masked"
+        finally:
+            ds.close()
+
     def test_preserves_data_integrity(self, s1_geotiff_dir: Path, s1_store_path: Path) -> None:
         vv, vh, mask = self._get_acq_paths(s1_geotiff_dir, "20230115t061234")
         ingest_s1tiling_acquisition(vv, vh, mask, s1_store_path, "ascending")


### PR DESCRIPTION
## Why

PR #172 ("deprecate v0, fix fill values, sanitize attributes") added the CF `_FillValue` attribute to float arrays so xarray can mask NaN nodata via `use_zarr_fill_value_as_mask=True` despite [pydata/xarray#11345](https://github.com/pydata/xarray/pull/11345) — the zarr-level `fill_value` field alone is **not** surfaced through xarray's encoding.

But **#172 never touched the S1 RTC ingest writer** (`s1_ingest.py`); it only patched the S2 (`s2_multiscale.py`) and S1-GRD (`geozarr.py` / `sentinel1_reprojection.py`) paths. As a result S1 RTC cubes carry **only `grid_mapping`** on their float bands, while S2 cubes carry `_FillValue` (`AAAAAAAA+H8=`) + `standard_name` + `units`:

| | `fill_value` (zarr) | `_FillValue` (attr) | other attrs |
|---|---|---|---|
| S2 `reflectance/r10m/b0x` | `NaN` | `AAAAAAAA+H8=` ✓ | long_name, units, grid_mapping |
| S1 RTC `*/r10m/{vv,vh}` (before) | `NaN` | **absent** ✗ | grid_mapping only |

This left S1 nodata unmaskable for generic xarray/CF consumers.

## What

- Set the CF `_FillValue` (FillValueCoder-encoded, matching S2) + `standard_name`/`units` on the float backscatter bands (`vv`/`vh`) at **every** multiscale level.
- Set `_FillValue` on the float condition arrays (`gamma_area`, `lia`).
- The two near-identical `vv`/`vh` creation loops — new store (`create_s1_store`) vs. new orbit added to an existing store (inline in `ingest_s1tiling_acquisition`) — are unified into a shared `_create_band_arrays` helper so they can't drift again. The inline path previously lacked the metadata, so with `orbit_direction: both` one orbit would have been correct and the other not.

### Deliberately **not** ported (S2-specific or N/A to the RTC writer)
- scale/offset + `CastValue` codec — S2 packed-integer reflectance; S1 `vv`/`vh` are float32, unpacked.
- v0 deprecation — S1 RTC is v1-only.
- `sanitize_array_attrs` — `s1_ingest` writes controlled attrs zarr-direct and never copies source EOPF attrs, so there is nothing to sanitize (the S1-GRD `sentinel1_reprojection.py` already received this in #172).

## Verification
- New tests (all green): `create_s1_store` unit (`test_float_bands_declare_cf_fill_value`), end-to-end ingest across **both** orbit-creation paths (`test_ingested_bands_declare_cf_fill_value`), and float-conditions coverage (`test_float_conditions_declare_cf_fill_value`).
- Full suite passes; ruff introduces no new findings.
- These tests guard the S1 RTC layout (`/{asc,desc}/rNNm/...`), which `test_array_attrs` only covered for the S2 `/measurements/` layout — the blind spot that let this regress.

> Existing cubes are remediated by re-ingest after this lands + a data-pipeline pin bump; no in-place migration here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sBdb17MWSAn7VEPSnqKJU