### PR TITLE
fix(s1-rtc): consolidate every orbit group, not just the last-ingested one

### DIFF
--- a/src/eopf_geozarr/conversion/s1_ingest.py
+++ b/src/eopf_geozarr/conversion/s1_ingest.py
@@ -743,12 +743,21 @@ def ingest_s1tiling_acquisition(
 
 
 def consolidate_s1_store(store_path: str | Path, orbit_direction: str) -> None:
-    """Consolidate metadata at orbit direction and root levels.
+    """Consolidate metadata for every orbit-direction group and the root.
 
     Must be called AFTER all ingestions complete — consolidated metadata
     caches array shapes and will become stale if called mid-ingestion.
+
+    Consolidates *every* orbit group present, not just ``orbit_direction``: the
+    pipeline ingests acquisitions one orbit at a time after stripping all
+    consolidated metadata (so ``time`` can resize), so consolidating only the
+    passed orbit would leave the other orbit's group unconsolidated on disk
+    (readers opening that orbit standalone then fall back to a listing).
+    ``orbit_direction`` is retained for logging / caller compatibility.
     """
-    zarr.consolidate_metadata(str(store_path), path=orbit_direction, zarr_format=3)
+    root = zarr.open_group(str(store_path), mode="r", zarr_format=3)
+    for orbit_name, _ in root.groups():
+        zarr.consolidate_metadata(str(store_path), path=orbit_name, zarr_format=3)
     zarr.consolidate_metadata(str(store_path), zarr_format=3)
     log.info(
         "Metadata consolidated",

--- a/tests/test_s1_rtc_ingest.py
+++ b/tests/test_s1_rtc_ingest.py
@@ -652,6 +652,26 @@ class TestConsolidation:
         r10m = root["ascending"]["r10m"]
         assert r10m["vv"].shape[0] == 2
 
+    def test_consolidate_all_orbits_present(
+        self, s1_geotiff_dir: Path, s1_store_path: Path
+    ) -> None:
+        """``consolidate_s1_store`` must leave EVERY orbit group consolidated on disk, not just the
+        one passed. The pipeline ingests acquisitions one orbit at a time after stripping all
+        consolidated metadata (so ``time`` can resize), so consolidating only the passed orbit left
+        staging cubes asc✓/desc✗. Each orbit group is checked **standalone**: a consolidated root
+        synthesises the child's view, so ``root[orbit].metadata.consolidated_metadata`` is a
+        false-green (non-None even when ``<orbit>/zarr.json`` lacks it).
+        """
+        vv1, vh1, mask1 = self._get_acq_paths(s1_geotiff_dir, "20230115t061234")
+        vv2, vh2, mask2 = self._get_acq_paths(s1_geotiff_dir, "20230127t061235")
+        ingest_s1tiling_acquisition(vv1, vh1, mask1, s1_store_path, "ascending")
+        ingest_s1tiling_acquisition(vv2, vh2, mask2, s1_store_path, "descending")
+        consolidate_s1_store(s1_store_path, "descending")  # only one orbit passed
+
+        for orbit in ("ascending", "descending"):
+            grp = zarr.open_group(str(s1_store_path / orbit), mode="r", zarr_format=3)
+            assert grp.metadata.consolidated_metadata is not None, f"{orbit} orbit not consolidated"
+
     def _get_acq_paths(self, geotiff_dir: Path, stamp: str) -> tuple[Path, Path, Path]:
         vv = geotiff_dir / f"s1a_32TQM_vv_ASC_037_{stamp}_GammaNaughtRTC.tif"
         vh = geotiff_dir / f"s1a_32TQM_vh_ASC_037_{stamp}_GammaNaughtRTC.tif"


### PR DESCRIPTION
## Why
S1 RTC cubes end up with only **one** orbit consolidated on disk — staging shows 30TWM asc✓/desc✗, 32TNN & 30UVU asc✗/desc✓.

**Root cause (traced + reproduced):** each acquisition is ingested by a separate pod that strips all consolidated metadata (so `time` can `resize`), ingests its single orbit, then calls `consolidate_s1_store(store, orbit_direction)` — which only re-consolidated the **one** orbit passed in. So whichever orbit is ingested *last* is the only one left with on-disk consolidated metadata.

## What
`consolidate_s1_store` now consolidates **every** orbit group present (`root.groups()`), then the root. Signature unchanged — `orbit_direction` is kept for logging / caller compatibility (no changes to the CLI or the data-pipeline callers).

```python
root = zarr.open_group(str(store_path), mode="r", zarr_format=3)
for orbit_name, _ in root.groups():
    zarr.consolidate_metadata(str(store_path), path=orbit_name, zarr_format=3)
zarr.consolidate_metadata(str(store_path), zarr_format=3)
```

**Safety:** the pipeline's minimal append-fetch already pulls *all* `zarr.json` (`ingest_v1_s1_rtc.py:336-337`); only bulk chunks are skipped. So both orbits' metadata is local when this runs — the same reason the root consolidation already produces a correct both-orbit view.

## Impact — cosmetic, not a correctness/deploy blocker
The **root** consolidated metadata is already complete for both orbits, and a consolidated root **synthesizes** a child orbit's view — so titiler (opens at root, selects via `/orbit:vv`) renders the unconsolidated orbit fine (verified: 30UVU ascending = HTTP 200 despite asc✗). The fix matters for clients that open a **single orbit group standalone** (e.g. following the STAC `<cube>.zarr/<orbit>` asset hrefs) with `consolidated=True`, which otherwise fall back to a listing. Existing cubes self-heal on their next re-ingest.

## Tests (TDD, RED→GREEN)
`tests/test_s1_rtc_ingest.py::TestConsolidation::test_consolidate_all_orbits_present` — ingests both orbits, calls `consolidate_s1_store(store, "descending")` (one orbit passed), asserts **both** orbit groups are consolidated **standalone**.

> ⚠️ The assertion opens each orbit group standalone — asserting via `root["ascending"].metadata.consolidated_metadata` is a **false-green** (a consolidated root synthesizes the child view, so it's non-None even on the buggy code; verified empirically).

RED on `ac3167f`, GREEN after the fix. Full data-model suite green; ruff/mypy add zero new findings vs baseline.

Stacks on #202; targets #180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)