### PR TITLE
fix(s1-rtc): per-band rescale for the RGB composite render

### DIFF
--- a/src/eopf_geozarr/stac/s1_rtc.py
+++ b/src/eopf_geozarr/stac/s1_rtc.py
@@ -38,16 +38,20 @@ def _rgb_render(orbit: str) -> dict[str, object]:
 
     Produces a 3-band false-colour composite (R=VV, G=VH, B=VV/VH ratio) that
     titiler renders into previews/tiles. ``bidx=[1]`` selects the single time
-    slice from each multi-band variable; the single ``rescale`` pair (linear
-    gamma0 units) is applied to every band.
+    slice from each multi-band variable. Each band gets its own ``rescale`` pair:
+    VV and VH are linear gamma0 (low values) while the VV/VH ratio spans ~1-15, so
+    a single shared pair blew the ratio band out to a flat blue/purple wash (and
+    dropped low-cross-pol water to transparent, making swaths look mislocated).
+    Per-band stretches keep the composite natural and the swath readable.
     """
     vv = f"/{orbit}:vv"
     vh = f"/{orbit}:vh"
     return {
         "title": "VV, VH, VV/VH composite",
         "expression": f"{vv};{vh};({vv})/({vh})",
-        # Linear gamma0 stretch tuned for the S1 RTC product (the 0.0,0.1 default was too bright).
-        "rescale": [[0.0, 0.2]],
+        # Per-band linear stretch: VV/VH are low-valued gamma0; the VV/VH ratio spans ~1-15.
+        # One shared pair saturated the ratio band (purple wash) and dropped low-cross-pol water.
+        "rescale": [[0.0, 0.4], [0.0, 0.1], [1.0, 15.0]],
         "bidx": [1],
         "tilesize": 256,
     }

--- a/tests/test_s1_stac.py
+++ b/tests/test_s1_stac.py
@@ -324,7 +324,7 @@ def test_render_extension_rgb_composite(tmp_path: Path) -> None:
 
     rgb = item.properties["renders"]["rgb"]
     assert rgb["expression"] == "/descending:vv;/descending:vh;(/descending:vv)/(/descending:vh)"
-    assert rgb["rescale"] == [[0.0, 0.2]]
+    assert rgb["rescale"] == [[0.0, 0.4], [0.0, 0.1], [1.0, 15.0]]
     assert rgb["bidx"] == [1]
     assert rgb["tilesize"] == 256
 


### PR DESCRIPTION
## What
The S1 RTC RGB composite render config supplied a **single** rescale pair `[[0.0, 0.2]]` for a **3-band** expression (`vv ; vh ; vv/vh`). titiler applied that one pair to all three bands, so the `vv/vh` ratio band (natural range ~1–15) saturated. Switch to per-band rescale in `_rgb_render`:

| band | rescale |
|------|---------|
| VV   | `[0.0, 0.4]` |
| VH   | `[0.0, 0.1]` |
| VV/VH ratio | `[1.0, 15.0]` |

## Why
Reported as ascending swaths "rendering at the wrong location." Investigation showed **geolocation is correct** — ascending and descending share a byte-identical coordinate grid, and edge cross-correlation of the ascending SAR against the basemap (Garonne/Gironde) peaks at ~50 m (sub-pixel). The bad look was purely the render:

- the saturated ratio band produced a flat blue/purple wash;
- low cross-pol (`vh ≈ 0`) water went `NaN` → **transparent**, so different orbits dropped out different regions and *looked* displaced.

Per-band stretches render a natural false-color composite (blue water, green/khaki vegetation, pink urban) with the full swath visible. Verified live against the raster API on tile 30TXQ (Arcachon/Gironde).

## Scope / caveats
- **Cosmetic, preview-only** — pixel placement is unchanged.
- Affects both the datacube and per-acquisition collections (single `_rgb_render` helper).
- Existing published STAC items keep the old rescale until **re-generated** (re-ingest or STAC rebuild) with a version carrying this commit.

## Tests
`uv run pytest tests/test_s1_stac.py tests/test_s1_stac_per_acquisition.py` → **34 passed**. The `test_render_extension_rgb_composite` assertion was updated to the new rescale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)