### PR TITLE
feat(s1-rtc): grid:code (MGRS tile) + grid extension on S1 RTC STAC items

### DIFF
--- a/src/eopf_geozarr/stac/s1_rtc.py
+++ b/src/eopf_geozarr/stac/s1_rtc.py
@@ -17,6 +17,7 @@ PROJ_EXT = "https://stac-extensions.github.io/projection/v2.0.0/schema.json"
 RENDER_EXT = "https://stac-extensions.github.io/render/v1.0.0/schema.json"
 DATACUBE_EXT = "https://stac-extensions.github.io/datacube/v2.2.0/schema.json"
 TIMESTAMPS_EXT = "https://stac-extensions.github.io/timestamps/v1.1.0/schema.json"
+GRID_EXT = "https://stac-extensions.github.io/grid/v1.1.0/schema.json"
 
 ZARR_MEDIA_TYPE = "application/vnd.zarr; version=3"
 
@@ -216,6 +217,9 @@ def build_s1_rtc_stac_item(zarr_store: str, collection_id: str) -> pystac.Item:
         # Projection extension
         "proj:code": preferred_proj_code,
         "proj:bbox": preferred_bbox,
+        # Grid extension: the Sentinel-2 MGRS tile this cube is gridded onto — a queryable tile id
+        # (enables tile-filtering the acquisitions collection and cube↔acquisition cross-links).
+        "grid:code": f"MGRS-{tile_id}",
         # Render extension: dual-pol RGB composite for previews/tiles (defaults to the preferred orbit)
         "renders": {"rgb": _rgb_render(preferred_orbit)},
     }
@@ -224,7 +228,7 @@ def build_s1_rtc_stac_item(zarr_store: str, collection_id: str) -> pystac.Item:
     if preferred["transform"] is not None:
         properties["proj:transform"] = preferred["transform"]
 
-    stac_extensions = [SAR_EXT, PROJ_EXT, RENDER_EXT, DATACUBE_EXT, TIMESTAMPS_EXT]
+    stac_extensions = [SAR_EXT, PROJ_EXT, RENDER_EXT, DATACUBE_EXT, TIMESTAMPS_EXT, GRID_EXT]
 
     # sat:orbit_state is single-valued, so it's only meaningful when the cube holds a single orbit. A
     # dual-orbit cube would mislabel half its slices — omit it there (per-acquisition items, which are

--- a/tests/test_s1_stac.py
+++ b/tests/test_s1_stac.py
@@ -92,6 +92,14 @@ def test_item_id_matches_tile_id(tmp_path: Path) -> None:
     assert item.id == "s1-rtc-31TCH"
 
 
+def test_grid_code_and_extension(tmp_path: Path) -> None:
+    """The cube declares the grid extension + grid:code = MGRS-{tile} (a queryable tile id)."""
+    store = _make_s1_store(tmp_path, {"descending": [(T1_NS, "S1A")]})
+    item = build_s1_rtc_stac_item(str(store), "sentinel-1-grd-rtc-staging")
+    assert item.properties["grid:code"] == "MGRS-31TCH"
+    assert "https://stac-extensions.github.io/grid/v1.1.0/schema.json" in item.stac_extensions
+
+
 def test_builds_from_non_consolidated_store(tmp_path: Path) -> None:
     """Regression: the builder must read a store that lacks root consolidated metadata.
 

--- a/tests/test_s1_stac_per_acquisition.py
+++ b/tests/test_s1_stac_per_acquisition.py
@@ -233,6 +233,14 @@ def test_per_slice_platform_and_no_datacube(tmp_path: Path) -> None:
         assert "created" not in item.properties
 
 
+def test_grid_code_inherited_from_cube(tmp_path: Path) -> None:
+    """Per-acquisition items inherit the cube's grid extension + grid:code (the MGRS tile)."""
+    store = _make_acq_cube(tmp_path, {"descending": [(T_EARLY, "S1A")]})
+    item = build_s1_rtc_per_acquisition_items(store, orbit="descending", collection_id="acq")[0]
+    assert item.properties["grid:code"] == "MGRS-31TCH"
+    assert "https://stac-extensions.github.io/grid/v1.1.0/schema.json" in item.stac_extensions
+
+
 def test_footprint_is_run_orbit_not_cube_union(tmp_path: Path) -> None:
     """A per-acq item must carry ITS orbit's footprint, not the cube's union of both orbits' extents."""
     # ascending shifted east so the cube union bbox is wider than the descending orbit alone.


### PR DESCRIPTION
## What

Adds the STAC **grid** extension with `grid:code = "MGRS-{tile}"` to S1 RTC STAC items. Cube-builder only (`build_s1_rtc_stac_item`); per-acquisition items **inherit** it automatically — `build_s1_rtc_per_acquisition_items` copies `{**base_dict}` (carries `stac_extensions`) and its property denylist excludes `grid:code`.

## Why

Makes the MGRS tile a first-class **queryable** property, which:
- lets STAC Browser filter the acquisitions collection by tile natively, and
- lets the cube↔acquisition cross-links (data-pipeline #300) filter on `grid:code='MGRS-{tile}'` instead of an id-prefix `LIKE`.

## Verification

- New tests: cube carries `grid:code="MGRS-31TCH"` + the grid extension; per-acquisition items inherit both.
- `tests/test_s1_stac.py` + `tests/test_s1_stac_per_acquisition.py` pass; full suite green (only pre-existing skips); ruff/mypy clean.

Once merged, data-pipeline bumps its `eopf-geozarr` pin to this sha and switches the cube→acq filter to `grid:code` (plan task L4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019z3eVtkSNHhN9vHd8QqGcf