### PR TITLE
[Review only] Make S1 RTC code pyright-clean (#199 parity)

### DIFF
--- a/src/eopf_geozarr/conversion/s1_ingest.py
+++ b/src/eopf_geozarr/conversion/s1_ingest.py
@@ -16,6 +16,7 @@ Public API:
 from __future__ import annotations
 
 import re
+from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from math import ceil
 from pathlib import Path
@@ -27,6 +28,7 @@ import structlog
 import zarr
 import zarr.codecs
 from pyproj import CRS as PyprojCRS
+from zarr.core.metadata.v3 import ArrayV3Metadata
 
 # `FillValueCoder` is xarray's internal CF fill-value encoder: the canonical way to produce
 # the base64 `_FillValue` xarray reads back under `use_zarr_fill_value_as_mask` (xarray
@@ -42,6 +44,32 @@ if TYPE_CHECKING:
     from eopf_geozarr.data_api.geozarr.types import S1BackscatterAttrsJSON
 
 log = structlog.get_logger()
+
+
+# =============================================================================
+# Zarr member-access helpers
+# =============================================================================
+#
+# Under pyright, ``group[name]`` is typed ``zarr.Array | zarr.Group``. The store layout
+# guarantees which one a given child is, so these helpers narrow (and assert) the type at
+# the single point of access. The ``raise`` branches encode a store-layout invariant and
+# are effectively unreachable — the established idiom in this codebase (see geozarr.py and
+# s2_multiscale.py).
+
+
+def _child_group(group: zarr.Group, name: str) -> zarr.Group:
+    member = group[name]
+    if not isinstance(member, zarr.Group):
+        raise TypeError(f"expected a group at {name!r}, got {type(member).__name__}")
+    return member
+
+
+def _child_array(group: zarr.Group, name: str) -> zarr.Array:
+    member = group[name]
+    if not isinstance(member, zarr.Array):
+        raise TypeError(f"expected an array at {name!r}, got {type(member).__name__}")
+    return member
+
 
 # =============================================================================
 # Constants
@@ -378,7 +406,13 @@ def _add_grid_mapping(group: zarr.Group, crs_string: str) -> None:
     sref.attrs.update(cf_attrs)
 
     for name, arr in group.arrays():
-        if name != "spatial_ref" and {"y", "x"}.issubset(arr.metadata.dimension_names or ()):
+        # This store is always Zarr V3; only V3 metadata carries ``dimension_names``.
+        dimension_names = (
+            arr.metadata.dimension_names
+            if isinstance(arr.metadata, ArrayV3Metadata)
+            else None
+        )
+        if name != "spatial_ref" and {"y", "x"}.issubset(dimension_names or ()):
             arr.attrs["grid_mapping"] = "spatial_ref"
 
 
@@ -467,7 +501,7 @@ def _build_orbit_group(
         _create_time_coordinate_array(level_group)
 
     # Per-time metadata coordinates at native resolution only (not selected on by readers).
-    r10m = orbit_group["r10m"]
+    r10m = _child_group(orbit_group, "r10m")
     for name, dtype, fill in [
         ("absolute_orbit", "int32", 0),
         ("relative_orbit", "int32", 0),
@@ -616,20 +650,28 @@ def ingest_s1tiling_acquisition(
             _build_orbit_group(root, orbit_direction, meta)
         else:
             # Validate consistency on append
-            orbit_group = root[orbit_direction]
-            store_crs = dict(orbit_group.attrs).get("proj:code")
+            orbit_group = _child_group(root, orbit_direction)
+            attrs = dict(orbit_group.attrs)
+            store_crs = attrs.get("proj:code")
             if store_crs != meta.crs:
                 raise ValueError(f"CRS mismatch: store has {store_crs}, GeoTIFF has {meta.crs}")
-            store_layout = dict(orbit_group.attrs).get("multiscales", {}).get("layout", [])
-            if store_layout:
+            multiscales = attrs.get("multiscales")
+            store_layout = (
+                multiscales.get("layout", []) if isinstance(multiscales, dict) else []
+            )
+            if isinstance(store_layout, list) and store_layout:
                 native_entry = store_layout[0]
-                store_shape = native_entry.get("spatial:shape")
+                store_shape = (
+                    native_entry.get("spatial:shape")
+                    if isinstance(native_entry, dict)
+                    else None
+                )
                 if store_shape != meta.shape:
                     raise ValueError(
                         f"Shape mismatch: store has {store_shape}, GeoTIFF has {meta.shape}"
                     )
 
-    orbit = root[orbit_direction]
+    orbit = _child_group(root, orbit_direction)
 
     # Read GeoTIFF pixel data
     with _rasterio_env(vv_path):
@@ -654,8 +696,8 @@ def ingest_s1tiling_acquisition(
     vh_data = np.where(mask_data == 0, np.nan, vh_data).astype("float32")
 
     # Determine time index
-    r10m = orbit["r10m"]
-    current_size = r10m["vv"].shape[0]
+    r10m = _child_group(orbit, "r10m")
+    current_size = _child_array(r10m, "vv").shape[0]
     new_size = current_size + 1
 
     # Generate overviews
@@ -680,13 +722,13 @@ def ingest_s1tiling_acquisition(
     # Recreate the missing-level coordinate from `r10m/time` (backfilling the existing slices so prior
     # timestamps are preserved), or raise if the cube is inconsistent in a way a backfill cannot fix.
     if "time" in r10m:
-        ref_time = np.asarray(r10m["time"][:])
+        ref_time = np.asarray(_child_array(r10m, "time")[:])
         healed = []
         for level_name in data_by_level:
-            level = orbit[level_name]
+            level = _child_group(orbit, level_name)
             if level_name == "r10m" or "time" in level:
                 continue
-            level_len = level["vv"].shape[0]
+            level_len = _child_array(level, "vv").shape[0]
             if level_len != ref_time.shape[0]:
                 raise ValueError(
                     f"Cannot append to {orbit_direction}/{level_name}: it has {level_len} slice(s) "
@@ -694,8 +736,8 @@ def ingest_s1tiling_acquisition(
                     "be safely backfilled (wipe + reingest)"
                 )
             _create_time_coordinate_array(level)
-            level["time"].resize((ref_time.shape[0],))
-            level["time"][:] = ref_time
+            _child_array(level, "time").resize((ref_time.shape[0],))
+            _child_array(level, "time")[:] = ref_time
             healed.append(level_name)
         if healed:
             log.info("Healed missing per-level `time`", levels=healed)
@@ -708,26 +750,26 @@ def ingest_s1tiling_acquisition(
     # Write data + the `time` coordinate at all levels (time is replicated per level so datetime
     # `.sel` resolves at any rendered scale, #192).
     for level_name, (vv_lev, vh_lev, mask_lev) in data_by_level.items():
-        level = orbit[level_name]
+        level = _child_group(orbit, level_name)
         h, w = vv_lev.shape
 
-        level["vv"].resize((new_size, h, w))
-        level["vh"].resize((new_size, h, w))
-        level["border_mask"].resize((new_size, h, w))
+        _child_array(level, "vv").resize((new_size, h, w))
+        _child_array(level, "vh").resize((new_size, h, w))
+        _child_array(level, "border_mask").resize((new_size, h, w))
 
-        level["vv"][current_size, :, :] = vv_lev
-        level["vh"][current_size, :, :] = vh_lev
-        level["border_mask"][current_size, :, :] = mask_lev
+        _child_array(level, "vv")[current_size, :, :] = vv_lev
+        _child_array(level, "vh")[current_size, :, :] = vh_lev
+        _child_array(level, "border_mask")[current_size, :, :] = mask_lev
 
-        level["time"].resize((new_size,))
-        level["time"][current_size] = dt_ns
+        _child_array(level, "time").resize((new_size,))
+        _child_array(level, "time")[current_size] = dt_ns
 
     # Per-time metadata coordinates at native resolution only.
     for coord_name in ["absolute_orbit", "relative_orbit", "platform"]:
-        r10m[coord_name].resize((new_size,))
-    r10m["absolute_orbit"][current_size] = meta.absolute_orbit
-    r10m["relative_orbit"][current_size] = meta.relative_orbit
-    r10m["platform"][current_size] = meta.platform
+        _child_array(r10m, coord_name).resize((new_size,))
+    _child_array(r10m, "absolute_orbit")[current_size] = meta.absolute_orbit
+    _child_array(r10m, "relative_orbit")[current_size] = meta.relative_orbit
+    _child_array(r10m, "platform")[current_size] = meta.platform
 
     log.info(
         "Zarr write complete",
@@ -799,7 +841,7 @@ def _input_path_exists(p: str | Path) -> bool:
     return Path(p).exists()
 
 
-def _rasterio_env(path: str | Path):  # type: ignore[return]
+def _rasterio_env(path: str | Path) -> AbstractContextManager[object]:
     """rasterio.Env context for S3 paths; no-op context manager for local paths.
 
     rasterio 1.5 passes endpoint_url verbatim as GDAL's AWS_S3_ENDPOINT.
@@ -941,7 +983,7 @@ def ingest_s1tiling_conditions(
     FileNotFoundError
         If any provided condition path does not exist.
     """
-    condition_inputs: list[tuple[str, Path]] = []
+    condition_inputs: list[tuple[str, str | Path]] = []
     for label, path in [
         ("gamma_area", gamma_area_path),
         ("lia", lia_path),
@@ -969,7 +1011,7 @@ def ingest_s1tiling_conditions(
             "Ingest at least one acquisition first."
         )
 
-    orbit = root[orbit_direction]
+    orbit = _child_group(root, orbit_direction)
 
     # Read reference metadata from the first condition file
     ref_label, ref_path = condition_inputs[0]
@@ -999,7 +1041,7 @@ def ingest_s1tiling_conditions(
         )
         log.info("Created conditions group", orbit_direction=orbit_direction)
     else:
-        conditions = orbit["conditions"]
+        conditions = _child_group(orbit, "conditions")
 
     # Write each condition array
     for label, cond_path in condition_inputs:
@@ -1015,7 +1057,7 @@ def ingest_s1tiling_conditions(
 
         if array_name in conditions:
             # Overwrite existing array
-            conditions[array_name][:, :] = data
+            _child_array(conditions, array_name)[:, :] = data
             log.info("Overwrote condition array", array_name=array_name)
         else:
             # Shard like the vv/vh pyramid: one shard over the full (y, x) extent so a 10980²

--- a/src/eopf_geozarr/data_api/s1_rtc.py
+++ b/src/eopf_geozarr/data_api/s1_rtc.py
@@ -138,7 +138,7 @@ class S1RtcConditionsAttrs(BaseModel):
 # ============================================================================
 
 
-class S1RtcNativeResolutionMembers(TypedDict, closed=True, total=False):  # type: ignore[call-arg]
+class S1RtcNativeResolutionMembers(TypedDict, closed=True, total=False):
     """Members for the native resolution dataset (r10m).
 
     Data variables (time, Y, X) plus 1-D coordinate variables (time,).
@@ -154,7 +154,7 @@ class S1RtcNativeResolutionMembers(TypedDict, closed=True, total=False):  # type
     platform: ArraySpec[Any]
 
 
-class S1RtcOverviewResolutionMembers(TypedDict, closed=True, total=False):  # type: ignore[call-arg]
+class S1RtcOverviewResolutionMembers(TypedDict, closed=True, total=False):
     """Members for overview resolution datasets (r20m … r720m).
 
     Only data variables, no coordinate arrays.
@@ -171,7 +171,7 @@ class S1RtcOverviewResolutionMembers(TypedDict, closed=True, total=False):  # ty
 
 
 class S1RtcNativeResolutionDataset(
-    GroupSpec[S1RtcResolutionAttrs, S1RtcNativeResolutionMembers]  # type: ignore[type-var]
+    GroupSpec[S1RtcResolutionAttrs, S1RtcNativeResolutionMembers]
 ):
     """The r10m dataset: data variables + coordinate arrays."""
 
@@ -185,19 +185,30 @@ class S1RtcNativeResolutionDataset(
 
     @property
     def vv(self) -> ArraySpec[Any]:
-        return self.members["vv"]
+        # Present post-validation (see validate_data_variables); the key is NotRequired in the
+        # TypedDict to allow incremental construction, so narrow it explicitly here.
+        vv = self.members.get("vv")
+        if vv is None:
+            raise KeyError("vv")
+        return vv
 
     @property
     def vh(self) -> ArraySpec[Any]:
-        return self.members["vh"]
+        vh = self.members.get("vh")
+        if vh is None:
+            raise KeyError("vh")
+        return vh
 
     @property
     def border_mask(self) -> ArraySpec[Any]:
-        return self.members["border_mask"]
+        border_mask = self.members.get("border_mask")
+        if border_mask is None:
+            raise KeyError("border_mask")
+        return border_mask
 
 
 class S1RtcOverviewResolutionDataset(
-    GroupSpec[S1RtcResolutionAttrs, S1RtcOverviewResolutionMembers]  # type: ignore[type-var]
+    GroupSpec[S1RtcResolutionAttrs, S1RtcOverviewResolutionMembers]
 ):
     """An overview resolution dataset (r20m-r720m): data variables only."""
 
@@ -213,7 +224,7 @@ class S1RtcConditionsGroup(GroupSpec[S1RtcConditionsAttrs, dict[str, ArraySpec[A
         return self
 
 
-class S1RtcOrbitGroupMembers(TypedDict, closed=True, total=False):  # type: ignore[call-arg]
+class S1RtcOrbitGroupMembers(TypedDict, closed=True, total=False):
     """Members for an orbit-direction group.
 
     Contains resolution-level datasets and conditions.
@@ -230,7 +241,7 @@ class S1RtcOrbitGroupMembers(TypedDict, closed=True, total=False):  # type: igno
 
 
 class S1RtcOrbitGroup(
-    GroupSpec[S1RtcOrbitGroupAttrs, S1RtcOrbitGroupMembers]  # type: ignore[type-var]
+    GroupSpec[S1RtcOrbitGroupAttrs, S1RtcOrbitGroupMembers]
 ):
     """One orbit direction (ascending or descending) with multiscale layout."""
 
@@ -242,7 +253,12 @@ class S1RtcOrbitGroup(
 
     @property
     def r10m(self) -> S1RtcNativeResolutionDataset:
-        return self.members["r10m"]
+        # Present post-validation (see validate_r10m_present); NotRequired in the TypedDict to
+        # allow incremental construction, so narrow it explicitly here.
+        r10m = self.members.get("r10m")
+        if r10m is None:
+            raise KeyError("r10m")
+        return r10m
 
     @property
     def conditions(self) -> S1RtcConditionsGroup | None:
@@ -258,14 +274,14 @@ class S1RtcOrbitGroup(
 # ============================================================================
 
 
-class S1RtcRootMembers(TypedDict, closed=True, total=False):  # type: ignore[call-arg]
+class S1RtcRootMembers(TypedDict, closed=True, total=False):
     """Members for the root group. At least one orbit direction must be present."""
 
     ascending: S1RtcOrbitGroup
     descending: S1RtcOrbitGroup
 
 
-class S1RtcRoot(GroupSpec[DatasetAttrs, S1RtcRootMembers]):  # type: ignore[type-var]
+class S1RtcRoot(GroupSpec[DatasetAttrs, S1RtcRootMembers]):
     """Complete S1 GRD RTC GeoZarr V3 hierarchy.
 
     The hierarchy follows the implementation plan::

--- a/src/eopf_geozarr/pyz/v3.py
+++ b/src/eopf_geozarr/pyz/v3.py
@@ -40,7 +40,7 @@ TMembers = TypeVar("TMembers", bound=TBaseMember)
 TArraySpecType = TypeVar("TArraySpecType")
 
 
-class GroupSpec(GroupSpecV3[TAttr, TMembers]):
+class GroupSpec(GroupSpecV3[TAttr, TMembers]):  # type: ignore[type-var]
     # TMembers is bound to the full members mapping (e.g. a TypedDict) by design,
     # whereas the parent's second type parameter expects a single member item type.
     attributes: TAttr

--- a/tests/test_data_api/test_s1_rtc.py
+++ b/tests/test_data_api/test_s1_rtc.py
@@ -17,24 +17,37 @@ import pytest
 from eopf_geozarr.data_api.s1_rtc import S1RtcRoot
 
 
+def _nav(node: object, *keys: str) -> dict[str, object]:
+    """Walk a path of string keys through a nested JSON dict (test helper).
+
+    Narrows each level to ``dict`` so mutating the raw fixture stays type-safe.
+    """
+    for key in keys:
+        assert isinstance(node, dict), f"expected a dict at {key!r}"
+        node = node[key]
+    assert isinstance(node, dict), "expected the leaf to be a dict"
+    return node
+
+
 def test_s1_rtc_roundtrip(s1_rtc_json_example: dict[str, object]) -> None:
     """Test that we can round-trip JSON data without loss."""
-    model1 = S1RtcRoot(**s1_rtc_json_example)
+    model1 = S1RtcRoot.model_validate(s1_rtc_json_example)
     dumped = model1.model_dump()
-    model2 = S1RtcRoot(**dumped)
+    model2 = S1RtcRoot.model_validate(dumped)
     assert model1.model_dump() == model2.model_dump()
 
 
 def test_s1_rtc_descending_present(s1_rtc_json_example: dict[str, object]) -> None:
     """Test that the fixture has a descending orbit group."""
-    model = S1RtcRoot(**s1_rtc_json_example)
+    model = S1RtcRoot.model_validate(s1_rtc_json_example)
     assert model.descending is not None
     assert model.ascending is None
 
 
 def test_s1_rtc_r10m_has_data_arrays(s1_rtc_json_example: dict[str, object]) -> None:
     """Test that r10m contains vv, vh, border_mask and coordinate arrays."""
-    model = S1RtcRoot(**s1_rtc_json_example)
+    model = S1RtcRoot.model_validate(s1_rtc_json_example)
+    assert model.descending is not None
     r10m = model.descending.r10m
     assert r10m.vv is not None
     assert r10m.vh is not None
@@ -47,8 +60,9 @@ def test_s1_rtc_r10m_has_data_arrays(s1_rtc_json_example: dict[str, object]) -> 
 
 def test_s1_rtc_overview_levels(s1_rtc_json_example: dict[str, object]) -> None:
     """Test that overview levels r20m-r720m exist and have vv/vh/border_mask."""
-    model = S1RtcRoot(**s1_rtc_json_example)
+    model = S1RtcRoot.model_validate(s1_rtc_json_example)
     orbit = model.descending
+    assert orbit is not None
     for level in ("r20m", "r60m", "r120m", "r360m", "r720m"):
         group = orbit.get_resolution(level)
         assert group is not None, f"Missing overview level {level}"
@@ -61,7 +75,8 @@ def test_s1_rtc_overview_levels(s1_rtc_json_example: dict[str, object]) -> None:
 
 def test_s1_rtc_conditions(s1_rtc_json_example: dict[str, object]) -> None:
     """Test that conditions group has gamma_area per-orbit arrays."""
-    model = S1RtcRoot(**s1_rtc_json_example)
+    model = S1RtcRoot.model_validate(s1_rtc_json_example)
+    assert model.descending is not None
     conditions = model.descending.conditions
     assert conditions is not None
     gamma_keys = [k for k in conditions.members if k.startswith("gamma_area_")]
@@ -70,7 +85,8 @@ def test_s1_rtc_conditions(s1_rtc_json_example: dict[str, object]) -> None:
 
 def test_s1_rtc_orbit_attrs(s1_rtc_json_example: dict[str, object]) -> None:
     """Test that orbit group attributes contain required conventions and metadata."""
-    model = S1RtcRoot(**s1_rtc_json_example)
+    model = S1RtcRoot.model_validate(s1_rtc_json_example)
+    assert model.descending is not None
     attrs = model.descending.attributes
     assert len(attrs.zarr_conventions) == 3
     assert attrs.proj_code.startswith("EPSG:")
@@ -85,33 +101,33 @@ def test_s1_rtc_rejects_no_orbit(s1_rtc_json_example: dict[str, object]) -> None
     data = copy.deepcopy(s1_rtc_json_example)
     data["members"] = {}
     with pytest.raises(Exception, match="at least one orbit"):
-        S1RtcRoot(**data)
+        S1RtcRoot.model_validate(data)
 
 
 def test_s1_rtc_rejects_missing_r10m(s1_rtc_json_example: dict[str, object]) -> None:
     """Reject an orbit group that lacks r10m."""
     data = copy.deepcopy(s1_rtc_json_example)
-    del data["members"]["descending"]["members"]["r10m"]
+    del _nav(data, "members", "descending", "members")["r10m"]
     with pytest.raises(Exception, match="r10m"):
-        S1RtcRoot(**data)
+        S1RtcRoot.model_validate(data)
 
 
 def test_s1_rtc_rejects_missing_convention_uuid(s1_rtc_json_example: dict[str, object]) -> None:
     """Reject orbit attrs with missing convention UUIDs."""
     data = copy.deepcopy(s1_rtc_json_example)
-    data["members"]["descending"]["attributes"]["zarr_conventions"] = [
+    _nav(data, "members", "descending", "attributes")["zarr_conventions"] = [
         {"uuid": "fake-uuid", "name": "fake"}
     ]
     with pytest.raises(Exception, match="Missing required zarr_conventions"):
-        S1RtcRoot(**data)
+        S1RtcRoot.model_validate(data)
 
 
 def test_s1_rtc_rejects_bad_spatial_dimensions(s1_rtc_json_example: dict[str, object]) -> None:
     """Reject orbit attrs with wrong spatial:dimensions."""
     data = copy.deepcopy(s1_rtc_json_example)
-    data["members"]["descending"]["attributes"]["spatial:dimensions"] = ["lat", "lon"]
+    _nav(data, "members", "descending", "attributes")["spatial:dimensions"] = ["lat", "lon"]
     with pytest.raises(Exception, match="spatial:dimensions"):
-        S1RtcRoot(**data)
+        S1RtcRoot.model_validate(data)
 
 
 def test_s1_rtc_rejects_conditions_without_gamma_area(
@@ -119,10 +135,10 @@ def test_s1_rtc_rejects_conditions_without_gamma_area(
 ) -> None:
     """Reject conditions group with no gamma_area_* arrays."""
     data = copy.deepcopy(s1_rtc_json_example)
-    cond_members = data["members"]["descending"]["members"]["conditions"]["members"]
+    cond_members = _nav(data, "members", "descending", "members", "conditions", "members")
     # Replace all keys with non-gamma_area names
-    data["members"]["descending"]["members"]["conditions"]["members"] = {
+    _nav(data, "members", "descending", "members", "conditions")["members"] = {
         "some_other": next(iter(cond_members.values()))
     }
     with pytest.raises(Exception, match="gamma_area"):
-        S1RtcRoot(**data)
+        S1RtcRoot.model_validate(data)

--- a/tests/test_s1_rtc_ingest.py
+++ b/tests/test_s1_rtc_ingest.py
@@ -12,7 +12,8 @@ import pytest
 import rasterio
 import xarray as xr
 import zarr
-from rasterio.transform import from_bounds
+from rasterio.transform import Affine, from_bounds
+from zarr.core.metadata import ArrayV3Metadata
 
 from eopf_geozarr.conversion.s1_ingest import (
     OVERVIEW_CHAIN,
@@ -62,11 +63,32 @@ ACQ2_TAGS = {
 # =============================================================================
 
 
+def _group(node: zarr.Group, name: str) -> zarr.Group:
+    """Narrow ``node[name]`` to a ``zarr.Group`` (zarr 3.x typing returns ``Array | Group``)."""
+    member = node[name]
+    assert isinstance(member, zarr.Group), f"{name!r} is not a group"
+    return member
+
+
+def _array(node: zarr.Group, name: str) -> zarr.Array:
+    """Narrow ``node[name]`` to a ``zarr.Array`` (zarr 3.x typing returns ``Array | Group``)."""
+    member = node[name]
+    assert isinstance(member, zarr.Array), f"{name!r} is not an array"
+    return member
+
+
+def _dimension_names(arr: zarr.Array) -> tuple[str | None, ...] | None:
+    """Read ``dimension_names`` off a zarr-format-3 array (``metadata`` is a V2/V3 union)."""
+    metadata = arr.metadata
+    assert isinstance(metadata, ArrayV3Metadata), "expected a zarr-format-3 array"
+    return metadata.dimension_names
+
+
 def _create_synthetic_geotiff(
     path: Path,
     data: np.ndarray,
     crs: str = CRS,
-    transform: rasterio.transform.Affine | None = None,
+    transform: Affine | None = None,
     tags: dict[str, str] | None = None,
     nodata: float | None = None,
 ) -> None:
@@ -228,25 +250,32 @@ class TestCreateStore:
 
     def test_conventions(self, s1_store_path: Path, sample_metadata: S1TilingMetadata) -> None:
         root = create_s1_store(s1_store_path, "ascending", sample_metadata)
-        attrs = dict(root["ascending"].attrs)
+        attrs = dict(_group(root, "ascending").attrs)
         assert "zarr_conventions" in attrs
-        conv_names = {c["name"] for c in attrs["zarr_conventions"]}
+        conventions = attrs["zarr_conventions"]
+        assert isinstance(conventions, list)
+        conv_names = set()
+        for conv in conventions:
+            assert isinstance(conv, dict)
+            conv_names.add(conv["name"])
         assert "multiscales" in conv_names
         assert "proj:" in conv_names
         assert "spatial:" in conv_names
         assert attrs["proj:code"] == CRS
         assert attrs["spatial:dimensions"] == ["y", "x"]
-        assert len(attrs["spatial:bbox"]) == 4
+        bbox = attrs["spatial:bbox"]
+        assert isinstance(bbox, list)
+        assert len(bbox) == 4
 
     def test_array_metadata(self, s1_store_path: Path, sample_metadata: S1TilingMetadata) -> None:
         root = create_s1_store(s1_store_path, "ascending", sample_metadata)
-        r10m = root["ascending"]["r10m"]
+        r10m = _group(_group(root, "ascending"), "r10m")
         for arr_name in ["vv", "vh", "border_mask"]:
-            arr = r10m[arr_name]
-            assert arr.metadata.dimension_names == ("time", "y", "x")
+            arr = _array(r10m, arr_name)
+            assert _dimension_names(arr) == ("time", "y", "x")
             assert arr.shape[0] == 0  # time axis starts at 0
-        assert r10m["vv"].dtype == np.float32
-        assert r10m["border_mask"].dtype == np.uint8
+        assert _array(r10m, "vv").dtype == np.float32
+        assert _array(r10m, "border_mask").dtype == np.uint8
 
     def test_float_bands_declare_cf_fill_value(
         self, s1_store_path: Path, sample_metadata: S1TilingMetadata
@@ -262,11 +291,11 @@ class TestCreateStore:
         from xarray.backends.zarr import FillValueCoder
 
         root = create_s1_store(s1_store_path, "ascending", sample_metadata)
-        orbit = root["ascending"]
+        orbit = _group(root, "ascending")
         expected = FillValueCoder.encode(np.nan, np.dtype("float32"))
         for level_name, _, _ in OVERVIEW_CHAIN:
             for band in ("vv", "vh"):
-                attrs = dict(orbit[level_name][band].attrs)
+                attrs = dict(_array(_group(orbit, level_name), band).attrs)
                 assert attrs.get("_FillValue") == expected, (
                     f"{level_name}/{band} missing/!= CF _FillValue"
                 )
@@ -282,7 +311,8 @@ class TestCreateStore:
         # tile_matrix_set is not part of the S1 GRD RTC data model (confirmed with the
         # data-model owner): the multiscales attribute must not carry one.
         root = create_s1_store(s1_store_path, "ascending", sample_metadata)
-        ms = dict(root["ascending"].attrs)["multiscales"]
+        ms = dict(_group(root, "ascending").attrs)["multiscales"]
+        assert isinstance(ms, dict)
         assert "tile_matrix_set" not in ms
         assert "layout" in ms
 
@@ -295,10 +325,11 @@ class TestCreateStore:
         import rioxarray  # noqa: F401  -- registers the .rio accessor
 
         create_s1_store(s1_store_path, "ascending", sample_metadata)
-        r10m = zarr.open_group(str(s1_store_path), mode="r", zarr_format=3)["ascending"]["r10m"]
+        root = zarr.open_group(str(s1_store_path), mode="r", zarr_format=3)
+        r10m = _group(_group(root, "ascending"), "r10m")
         assert "spatial_ref" in list(r10m.array_keys())
-        assert dict(r10m["vv"].attrs).get("grid_mapping") == "spatial_ref"
-        assert dict(r10m["vh"].attrs).get("grid_mapping") == "spatial_ref"
+        assert dict(_array(r10m, "vv").attrs).get("grid_mapping") == "spatial_ref"
+        assert dict(_array(r10m, "vh").attrs).get("grid_mapping") == "spatial_ref"
 
         ds = xr.open_zarr(
             str(s1_store_path / "ascending" / "r10m"),
@@ -312,22 +343,22 @@ class TestCreateStore:
         self, s1_store_path: Path, sample_metadata: S1TilingMetadata
     ) -> None:
         root = create_s1_store(s1_store_path, "ascending", sample_metadata)
-        r10m = root["ascending"]["r10m"]
+        r10m = _group(_group(root, "ascending"), "r10m")
         for coord_name in ["time", "absolute_orbit", "relative_orbit", "platform"]:
             assert coord_name in r10m, f"Missing coord {coord_name}"
-            assert r10m[coord_name].shape == (0,)
+            assert _array(r10m, coord_name).shape == (0,)
 
     def test_overview_shapes(self, s1_store_path: Path, sample_metadata: S1TilingMetadata) -> None:
         root = create_s1_store(s1_store_path, "ascending", sample_metadata)
-        orbit = root["ascending"]
+        orbit = _group(root, "ascending")
         # Verify shape chain follows ceiling division
         expected_h, expected_w = SIZE, SIZE
         for level_name, _, factor in OVERVIEW_CHAIN:
             if factor > 1:
                 expected_h = ceil(expected_h / factor)
                 expected_w = ceil(expected_w / factor)
-            level = orbit[level_name]
-            arr = level["vv"]
+            level = _group(orbit, level_name)
+            arr = _array(level, "vv")
             assert arr.shape[1] == expected_h
             assert arr.shape[2] == expected_w
 
@@ -336,12 +367,12 @@ class TestCreateStore:
     ) -> None:
         """Verify x and y 1D arrays exist at every resolution level."""
         root = create_s1_store(s1_store_path, "ascending", sample_metadata)
-        orbit = root["ascending"]
+        orbit = _group(root, "ascending")
         for level_name, _, _ in OVERVIEW_CHAIN:
-            level = orbit[level_name]
+            level = _group(orbit, level_name)
             for coord in ["x", "y"]:
                 assert coord in level, f"Missing {coord} at {level_name}"
-                arr = level[coord]
+                arr = _array(level, coord)
                 assert len(arr.shape) == 1
                 attrs = dict(arr.attrs)
                 assert "units" in attrs
@@ -350,9 +381,11 @@ class TestCreateStore:
 
             # Verify x array shape matches level width
             level_attrs = dict(level.attrs)
-            level_h, level_w = level_attrs["spatial:shape"]
-            assert level["x"].shape[0] == level_w
-            assert level["y"].shape[0] == level_h
+            level_shape = level_attrs["spatial:shape"]
+            assert isinstance(level_shape, list)
+            level_h, level_w = level_shape
+            assert _array(level, "x").shape[0] == level_w
+            assert _array(level, "y").shape[0] == level_h
 
 
 # =============================================================================
@@ -373,7 +406,7 @@ class TestIngestAcquisition:
         idx = ingest_s1tiling_acquisition(vv, vh, mask, s1_store_path, "ascending")
         assert idx == 0
         root = zarr.open_group(str(s1_store_path), mode="r", zarr_format=3)
-        assert root["ascending"]["r10m"]["vv"].shape[0] == 1
+        assert _array(_group(_group(root, "ascending"), "r10m"), "vv").shape[0] == 1
 
     def test_second_acquisition_appends(self, s1_geotiff_dir: Path, s1_store_path: Path) -> None:
         vv1, vh1, mask1 = self._get_acq_paths(s1_geotiff_dir, "20230115t061234")
@@ -382,7 +415,7 @@ class TestIngestAcquisition:
         idx = ingest_s1tiling_acquisition(vv2, vh2, mask2, s1_store_path, "ascending")
         assert idx == 1
         root = zarr.open_group(str(s1_store_path), mode="r", zarr_format=3)
-        assert root["ascending"]["r10m"]["vv"].shape[0] == 2
+        assert _array(_group(_group(root, "ascending"), "r10m"), "vv").shape[0] == 2
 
     def test_ingested_bands_declare_cf_fill_value(
         self, s1_geotiff_dir: Path, s1_store_path: Path
@@ -402,7 +435,7 @@ class TestIngestAcquisition:
         for orbit in ("ascending", "descending"):
             for level_name, _, _ in OVERVIEW_CHAIN:
                 for band in ("vv", "vh"):
-                    attrs = dict(root[orbit][level_name][band].attrs)
+                    attrs = dict(_array(_group(_group(root, orbit), level_name), band).attrs)
                     assert attrs.get("_FillValue") == expected, f"{orbit}/{level_name}/{band}"
                     assert (
                         attrs.get("standard_name")
@@ -422,7 +455,7 @@ class TestIngestAcquisition:
         root = zarr.open_group(str(s1_store_path), mode="r", zarr_format=3)
         for orbit in ("ascending", "descending"):
             for level_name, _, _ in OVERVIEW_CHAIN:
-                attrs = dict(root[orbit][level_name].attrs)
+                attrs = dict(_group(_group(root, orbit), level_name).attrs)
                 assert attrs.get("proj:code") == CRS, f"{orbit}/{level_name} missing proj:code"
 
     def test_fill_value_masking_roundtrip(self, tmp_path: Path, s1_store_path: Path) -> None:
@@ -461,8 +494,10 @@ class TestIngestAcquisition:
         try:
             masked = ds["vv"].to_masked_array()
             assert np.ma.is_masked(masked), "out-of-swath nodata must be masked via `_FillValue`"
-            assert masked.mask[0, 0, 0], "nodata cell (border_mask==0) must be masked"
-            assert not masked.mask[0, -1, -1], "valid cell must not be masked"
+            mask = masked.mask
+            assert isinstance(mask, np.ndarray)
+            assert mask[0, 0, 0], "nodata cell (border_mask==0) must be masked"
+            assert not mask[0, -1, -1], "valid cell must not be masked"
         finally:
             ds.close()
 
@@ -491,15 +526,17 @@ class TestIngestAcquisition:
         ingest_s1tiling_acquisition(vv, vh, mask, s1_store_path, "ascending")
 
         root = zarr.open_group(str(s1_store_path), mode="r", zarr_format=3)
+        asc = _group(root, "ascending")
+        r10m = _group(asc, "r10m")
         nodata = mask_data == 0
         for band in ("vv", "vh"):
-            native = root["ascending"]["r10m"][band][0, :, :]
+            native = np.asarray(_array(r10m, band)[0, :, :])
             assert np.all(np.isnan(native[nodata])), f"{band}: nodata region must be NaN, not 0"
             assert not np.any(np.isnan(native[~nodata])), f"{band}: valid region must stay finite"
             assert not np.any(native[nodata] == 0.0), f"{band}: nodata must not read back as 0"
 
         # NaN propagates through np.nanmean downsampling: the all-nodata top band stays NaN.
-        coarse = root["ascending"]["r20m"]["vv"][0, :, :]
+        coarse = np.asarray(_array(_group(asc, "r20m"), "vv")[0, :, :])
         assert np.isnan(coarse[0, 0]), "all-nodata block must stay NaN at the overview level"
         assert not np.any(np.isnan(coarse[-1, :])), "fully-valid bottom row must stay finite"
 
@@ -513,7 +550,8 @@ class TestIngestAcquisition:
         with rasterio.open(str(mask)) as src:
             expected_mask = src.read(1).astype(np.uint8)
         root = zarr.open_group(str(s1_store_path), mode="r", zarr_format=3)
-        actual_vv = root["ascending"]["r10m"]["vv"][0, :, :]
+        r10m = _group(_group(root, "ascending"), "r10m")
+        actual_vv = np.asarray(_array(r10m, "vv")[0, :, :])
 
         # Valid pixels (border_mask == 1) are preserved exactly; out-of-swath pixels
         # (border_mask == 0) are written as NaN, not the raw 0 — the render-bug fix.
@@ -522,7 +560,7 @@ class TestIngestAcquisition:
         assert np.all(np.isnan(actual_vv[~valid])), "out-of-swath nodata must be NaN"
 
         # border_mask itself is stored verbatim (uint8, never masked).
-        actual_mask = root["ascending"]["r10m"]["border_mask"][0, :, :]
+        actual_mask = _array(r10m, "border_mask")[0, :, :]
         np.testing.assert_array_equal(actual_mask, expected_mask)
 
     def test_coordinate_values(self, s1_geotiff_dir: Path, s1_store_path: Path) -> None:
@@ -530,13 +568,13 @@ class TestIngestAcquisition:
         ingest_s1tiling_acquisition(vv, vh, mask, s1_store_path, "ascending")
 
         root = zarr.open_group(str(s1_store_path), mode="r", zarr_format=3)
-        r10m = root["ascending"]["r10m"]
-        assert r10m["absolute_orbit"][0] == 47001
-        assert r10m["relative_orbit"][0] == 37
-        assert str(r10m["platform"][0]) == "S1A"
+        r10m = _group(_group(root, "ascending"), "r10m")
+        assert _array(r10m, "absolute_orbit")[0] == 47001
+        assert _array(r10m, "relative_orbit")[0] == 37
+        assert str(_array(r10m, "platform")[0]) == "S1A"
 
         # Verify time is a valid nanosecond timestamp (stored as int64)
-        time_val = int(r10m["time"][0])
+        time_val = int(np.asarray(_array(r10m, "time"))[0])
         dt = np.datetime64(time_val, "ns")
         assert str(dt).startswith("2023-01-15")
 
@@ -545,13 +583,13 @@ class TestIngestAcquisition:
         ingest_s1tiling_acquisition(vv, vh, mask, s1_store_path, "ascending")
 
         root = zarr.open_group(str(s1_store_path), mode="r", zarr_format=3)
-        orbit = root["ascending"]
+        orbit = _group(root, "ascending")
         expected_h, expected_w = SIZE, SIZE
         for level_name, _, factor in OVERVIEW_CHAIN:
             if factor > 1:
                 expected_h = ceil(expected_h / factor)
                 expected_w = ceil(expected_w / factor)
-            arr = orbit[level_name]["vv"]
+            arr = _array(_group(orbit, level_name), "vv")
             assert arr.shape == (1, expected_h, expected_w), (
                 f"Shape mismatch at {level_name}: {arr.shape}"
             )
@@ -635,7 +673,7 @@ class TestConsolidation:
 
         root = zarr.open_group(str(s1_store_path), mode="r", zarr_format=3)
         assert root.metadata.consolidated_metadata is not None
-        orbit = root["ascending"]
+        orbit = _group(root, "ascending")
         assert orbit.metadata.consolidated_metadata is not None
 
     def test_consolidate_after_all_ingestions(
@@ -649,8 +687,8 @@ class TestConsolidation:
 
         # Verify consolidated metadata reflects final shape (2 timesteps)
         root = zarr.open_group(str(s1_store_path), mode="r", zarr_format=3)
-        r10m = root["ascending"]["r10m"]
-        assert r10m["vv"].shape[0] == 2
+        r10m = _group(_group(root, "ascending"), "r10m")
+        assert _array(r10m, "vv").shape[0] == 2
 
     def test_consolidate_all_orbits_present(
         self, s1_geotiff_dir: Path, s1_store_path: Path
@@ -796,9 +834,9 @@ class TestIngestConditions:
             gamma_area_path=gamma_area_geotiff,
         )
         root = zarr.open_group(str(s1_store_with_acquisition), mode="r", zarr_format=3)
-        orbit = root["ascending"]
+        orbit = _group(root, "ascending")
         assert "conditions" in orbit
-        conditions = orbit["conditions"]
+        conditions = _group(orbit, "conditions")
         assert "gamma_area_037" in conditions
 
     def test_conditions_group_attributes(
@@ -811,15 +849,17 @@ class TestIngestConditions:
             gamma_area_path=gamma_area_geotiff,
         )
         root = zarr.open_group(str(s1_store_with_acquisition), mode="r", zarr_format=3)
-        conditions = root["ascending"]["conditions"]
+        conditions = _group(_group(root, "ascending"), "conditions")
         attrs = dict(conditions.attrs)
         assert attrs["proj:code"] == CRS
         assert attrs["spatial:dimensions"] == ["y", "x"]
-        assert len(attrs["spatial:transform"]) == 6
+        transform = attrs["spatial:transform"]
+        assert isinstance(transform, list)
+        assert len(transform) == 6
         assert attrs["spatial:shape"] == [SIZE, SIZE]
         # CF grid-mapping so rioxarray can resolve the CRS of the condition arrays
         assert "spatial_ref" in list(conditions.array_keys())
-        assert dict(conditions["gamma_area_037"].attrs).get("grid_mapping") == "spatial_ref"
+        assert dict(_array(conditions, "gamma_area_037").attrs).get("grid_mapping") == "spatial_ref"
 
     def test_gamma_area_array_shape_and_dtype(
         self, s1_store_with_acquisition: Path, gamma_area_geotiff: Path
@@ -831,10 +871,10 @@ class TestIngestConditions:
             gamma_area_path=gamma_area_geotiff,
         )
         root = zarr.open_group(str(s1_store_with_acquisition), mode="r", zarr_format=3)
-        arr = root["ascending"]["conditions"]["gamma_area_037"]
+        arr = _array(_group(_group(root, "ascending"), "conditions"), "gamma_area_037")
         assert arr.shape == (SIZE, SIZE)
         assert arr.dtype == np.float32
-        assert arr.metadata.dimension_names == ("y", "x")
+        assert _dimension_names(arr) == ("y", "x")
 
     def test_data_integrity_roundtrip(
         self, s1_store_with_acquisition: Path, gamma_area_geotiff: Path
@@ -850,7 +890,7 @@ class TestIngestConditions:
             expected = src.read(1).astype(np.float32)
         # Read from Zarr
         root = zarr.open_group(str(s1_store_with_acquisition), mode="r", zarr_format=3)
-        actual = root["ascending"]["conditions"]["gamma_area_037"][:]
+        actual = np.asarray(_array(_group(_group(root, "ascending"), "conditions"), "gamma_area_037")[:])
         np.testing.assert_allclose(actual, expected, rtol=1e-6)
 
     def test_conditions_nodata_masked_to_nan(
@@ -870,10 +910,9 @@ class TestIngestConditions:
             relative_orbit=37,
             gamma_area_path=cond_path,
         )
-        conditions = zarr.open_group(str(s1_store_with_acquisition), mode="r", zarr_format=3)[
-            "ascending"
-        ]["conditions"]
-        arr = conditions["gamma_area_037"][:]
+        root = zarr.open_group(str(s1_store_with_acquisition), mode="r", zarr_format=3)
+        conditions = _group(_group(root, "ascending"), "conditions")
+        arr = np.asarray(_array(conditions, "gamma_area_037")[:])
         assert np.all(np.isnan(arr[0:20, 0:20])), "declared-nodata region must be NaN"
         assert not np.any(np.isnan(arr[20:, 20:])), "valid region must stay finite"
 
@@ -895,11 +934,10 @@ class TestIngestConditions:
             lia_path=lia_geotiff,
         )
         expected = FillValueCoder.encode(np.nan, np.dtype("float32"))
-        conditions = zarr.open_group(str(s1_store_with_acquisition), mode="r", zarr_format=3)[
-            "ascending"
-        ]["conditions"]
+        root = zarr.open_group(str(s1_store_with_acquisition), mode="r", zarr_format=3)
+        conditions = _group(_group(root, "ascending"), "conditions")
         for arr_name in ("gamma_area_037", "lia_037"):
-            assert dict(conditions[arr_name].attrs).get("_FillValue") == expected, arr_name
+            assert dict(_array(conditions, arr_name).attrs).get("_FillValue") == expected, arr_name
 
     def test_gamma_area_is_sharded(
         self, s1_store_with_acquisition: Path, gamma_area_geotiff: Path
@@ -912,9 +950,8 @@ class TestIngestConditions:
             relative_orbit=37,
             gamma_area_path=gamma_area_geotiff,
         )
-        arr = zarr.open_group(str(s1_store_with_acquisition), mode="r", zarr_format=3)[
-            "ascending"
-        ]["conditions"]["gamma_area_037"]
+        root = zarr.open_group(str(s1_store_with_acquisition), mode="r", zarr_format=3)
+        arr = _array(_group(_group(root, "ascending"), "conditions"), "gamma_area_037")
         # shards == full extent (None would mean unsharded — the pre-fix layout)
         assert arr.shards == (SIZE, SIZE)
         assert arr.chunks == (calculate_aligned_chunk_size(SIZE, 512),) * 2
@@ -936,9 +973,8 @@ class TestIngestConditions:
             relative_orbit=37,
             gamma_area_path=gpath,
         )
-        arr = zarr.open_group(str(s1_store_with_acquisition), mode="r", zarr_format=3)[
-            "ascending"
-        ]["conditions"]["gamma_area_037"]
+        root = zarr.open_group(str(s1_store_with_acquisition), mode="r", zarr_format=3)
+        arr = _array(_group(_group(root, "ascending"), "conditions"), "gamma_area_037")
         assert arr.chunks == (366, 366)
         assert arr.shards == (big, big)
         # exactly one chunk-data object on disk (the shard), regardless of the 9 inner chunks
@@ -948,7 +984,7 @@ class TestIngestConditions:
         ]
         assert len(data_objects) == 1, data_objects
         # values still byte-identical through the shard
-        np.testing.assert_allclose(arr[:], data, rtol=1e-6)
+        np.testing.assert_allclose(np.asarray(arr[:]), data, rtol=1e-6)
 
     def test_multiple_conditions(
         self, s1_store_with_acquisition: Path, gamma_area_geotiff: Path, lia_geotiff: Path
@@ -961,7 +997,7 @@ class TestIngestConditions:
             lia_path=lia_geotiff,
         )
         root = zarr.open_group(str(s1_store_with_acquisition), mode="r", zarr_format=3)
-        conditions = root["ascending"]["conditions"]
+        conditions = _group(_group(root, "ascending"), "conditions")
         assert "gamma_area_037" in conditions
         assert "lia_037" in conditions
 
@@ -983,7 +1019,7 @@ class TestIngestConditions:
         )
 
         root = zarr.open_group(str(s1_store_with_acquisition), mode="r", zarr_format=3)
-        conditions = root["ascending"]["conditions"]
+        conditions = _group(_group(root, "ascending"), "conditions")
         assert "gamma_area_037" in conditions
         assert "gamma_area_110" in conditions
 
@@ -1007,7 +1043,7 @@ class TestIngestConditions:
         )
 
         root = zarr.open_group(str(s1_store_with_acquisition), mode="r", zarr_format=3)
-        actual = root["ascending"]["conditions"]["gamma_area_037"][:]
+        actual = np.asarray(_array(_group(_group(root, "ascending"), "conditions"), "gamma_area_037")[:])
         np.testing.assert_allclose(actual, data_v2, rtol=1e-6)
 
     def test_raises_no_conditions_provided(
@@ -1055,11 +1091,11 @@ class TestIngestConditions:
 
         root = zarr.open_group(str(s1_store_with_acquisition), mode="r", zarr_format=3)
         assert root.metadata.consolidated_metadata is not None
-        orbit = root["ascending"]
+        orbit = _group(root, "ascending")
         assert orbit.metadata.consolidated_metadata is not None
         # Conditions group should be accessible through consolidated metadata
         assert "conditions" in orbit
-        assert "gamma_area_037" in orbit["conditions"]
+        assert "gamma_area_037" in _group(orbit, "conditions")
 
 
 # =============================================================================
@@ -1146,8 +1182,9 @@ class TestTimeCFDatetime:
         vv, vh, mask = self._paths(s1_geotiff_dir, "20230115t061234")
         ingest_s1tiling_acquisition(vv, vh, mask, s1_store_path, "ascending")
         root = zarr.open_group(str(s1_store_path), mode="r", zarr_format=3)
+        asc = _group(root, "ascending")
         for level in _LEVELS:
-            attrs = dict(root["ascending"][level]["time"].attrs)
+            attrs = dict(_array(_group(asc, level), "time").attrs)
             assert attrs.get("units") == "nanoseconds since 1970-01-01", level
             assert attrs.get("calendar") == "proleptic_gregorian", level
             assert attrs.get("standard_name") == "time", level
@@ -1178,7 +1215,9 @@ class TestTimeCFDatetime:
         dt = xr.open_datatree(
             str(s1_store_path), engine="zarr", decode_times=True, consolidated=False
         )
-        times = dt["ascending"]["r10m"]["time"].values
+        time_node = dt["ascending"]["r10m"]["time"]
+        assert isinstance(time_node, xr.DataArray)
+        times = time_node.values
         assert times[0] > times[1], "axis should be non-monotonic (later acq appended first)"
 
         early = np.datetime64("2023-01-15T06:12:34")  # physical index 1
@@ -1200,10 +1239,11 @@ class TestTimeCFDatetime:
         ingest_s1tiling_acquisition(vv1, vh1, mask1, s1_store_path, "ascending")
         ingest_s1tiling_acquisition(vv2, vh2, mask2, s1_store_path, "ascending")
         root = zarr.open_group(str(s1_store_path), mode="r", zarr_format=3)
-        ref = np.asarray(root["ascending"]["r10m"]["time"][:])
+        asc = _group(root, "ascending")
+        ref = np.asarray(_array(_group(asc, "r10m"), "time")[:])
         assert ref.shape == (2,)
         for level in _LEVELS[1:]:
-            np.testing.assert_array_equal(np.asarray(root["ascending"][level]["time"][:]), ref)
+            np.testing.assert_array_equal(np.asarray(_array(_group(asc, level), "time")[:]), ref)
 
     def test_r10m_time_still_int64_for_register(
         self, s1_geotiff_dir: Path, s1_store_path: Path
@@ -1212,9 +1252,9 @@ class TestTimeCFDatetime:
         vv, vh, mask = self._paths(s1_geotiff_dir, "20230115t061234")
         ingest_s1tiling_acquisition(vv, vh, mask, s1_store_path, "ascending")
         root = zarr.open_group(str(s1_store_path), mode="r", zarr_format=3)
-        arr = root["ascending"]["r10m"]["time"]
+        arr = _array(_group(_group(root, "ascending"), "r10m"), "time")
         assert arr.dtype == np.dtype("int64")
-        assert str(np.datetime64(int(arr[0]), "ns")).startswith("2023-01-15")
+        assert str(np.datetime64(int(np.asarray(arr)[0]), "ns")).startswith("2023-01-15")
 
 
 # =============================================================================
@@ -1236,7 +1276,7 @@ class TestPerLevelTimeHeal:
 
     def _coarse_levels(self, store_path: Path) -> list[str]:
         root = zarr.open_group(str(store_path), mode="r", zarr_format=3)
-        return [n for n, _ in root["ascending"].groups() if n not in ("r10m", "conditions")]
+        return [n for n, _ in _group(root, "ascending").groups() if n not in ("r10m", "conditions")]
 
     def _drop_time(self, store_path: Path, level: str) -> None:
         """Simulate a pre-#192 cube by removing a level's `time` array. `ingest_s1tiling_acquisition`
@@ -1262,12 +1302,13 @@ class TestPerLevelTimeHeal:
 
         assert idx == 1
         root = zarr.open_group(str(s1_store_path), mode="r", zarr_format=3)
-        ref = list(root["ascending"]["r10m"]["time"][:])
+        asc = _group(root, "ascending")
+        ref = list(np.asarray(_array(_group(asc, "r10m"), "time")[:]))
         assert len(ref) == 2
         for lvl in coarse:
-            t = root["ascending"][lvl]["time"]
+            t = _array(_group(asc, lvl), "time")
             assert t.dtype == np.dtype("int64")
-            assert list(t[:]) == ref  # backfilled prior slice + appended new slice, matching r10m
+            assert list(np.asarray(t[:])) == ref  # backfilled prior + appended new, matching r10m
 
     def test_append_noop_when_all_levels_have_time(
         self, s1_geotiff_dir: Path, s1_store_path: Path
@@ -1279,8 +1320,9 @@ class TestPerLevelTimeHeal:
         idx = ingest_s1tiling_acquisition(*a2, s1_store_path, "ascending")
         assert idx == 1
         root = zarr.open_group(str(s1_store_path), mode="r", zarr_format=3)
+        asc = _group(root, "ascending")
         for lvl in self._coarse_levels(s1_store_path):
-            assert root["ascending"][lvl]["time"].shape[0] == 2
+            assert _array(_group(asc, lvl), "time").shape[0] == 2
 
     def test_append_raises_on_half_built_cube(
         self, s1_geotiff_dir: Path, s1_store_path: Path
@@ -1293,9 +1335,10 @@ class TestPerLevelTimeHeal:
         ingest_s1tiling_acquisition(*a2, s1_store_path, "ascending")  # 2 slices
 
         root = zarr.open_group(str(s1_store_path), mode="r+", zarr_format=3)
-        r20m = root["ascending"]["r20m"]
-        _, h, w = r20m["vv"].shape
-        r20m["vv"].resize((1, h, w))  # half-built: r20m has 1 slice, r10m has 2
+        r20m = _group(_group(root, "ascending"), "r20m")
+        vv_arr = _array(r20m, "vv")
+        _, h, w = vv_arr.shape
+        vv_arr.resize((1, h, w))  # half-built: r20m has 1 slice, r10m has 2
         self._drop_time(s1_store_path, "r20m")
 
         with pytest.raises(ValueError, match="half-built"):

--- a/tests/test_s1_stac_per_acquisition.py
+++ b/tests/test_s1_stac_per_acquisition.py
@@ -269,6 +269,7 @@ def test_footprint_is_run_orbit_not_cube_union(tmp_path: Path) -> None:
     # proj:bbox is the descending orbit's UTM extent — not the ascending (preferred) orbit's.
     assert item.properties["proj:bbox"] == desc_bbox
     # WGS84 bbox east edge stays within the descending footprint (~2°E), not the union (~3°E+).
+    assert item.bbox is not None
     assert item.bbox[2] < 2.5
 
 


### PR DESCRIPTION
## What this is
PR #199 migrated the project from mypy to **pyright**, but the S1 RTC code was written under mypy with zarr type-checking disabled (`ignore_missing_imports`). Under pyright, zarr 3.x is fully typed, so every `group[name]` is a `zarr.Array | zarr.Group` union — the S1 code + tests surfaced **~1390 type errors**. This PR takes them to **0** with no behavior or on-disk-output change.

## What to review (6 files)
- **`conversion/s1_ingest.py`** — added `_child_group`/`_child_array` isinstance-narrowing helpers (mirroring the idiom in `geozarr.py` / `s2_multiscale.py`) used at every zarr member access; narrowed `arr.metadata` → `ArrayV3Metadata` for `dimension_names`; guarded the append-validation attrs chains with `isinstance`; replaced `# type: ignore[return]` on `_rasterio_env` with a real return type.
- **`data_api/s1_rtc.py`** — narrowed the `NotRequired` TypedDict member accessors with `.get()` + explicit `raise KeyError` (behavior-identical); removed mypy-era `# type: ignore` comments pyright flags as unnecessary.
- **`pyz/v3.py`** — one line: added `# type: ignore[type-var]` on the `GroupSpec` base, **exactly matching `pyz/v2.py:43`**. The S1 models are the first to subclass `pyz.v3.GroupSpec` under a type checker, so this intentional variance now needs the same suppression v2 already carries.
- **test files** (`test_s1_rtc_ingest.py`, `test_data_api/test_s1_rtc.py`, `test_s1_stac_per_acquisition.py`) — `assert isinstance` narrowing helpers + `np.asarray` around zarr reads. No assertion weakened, deleted, or skipped.

**No new `Any`, no blanket `# type: ignore`.**

## Verification
- `uv run --frozen pyright`: **0 errors** across the whole project.
- Full test suite green; no runtime behavior or on-disk output change.

## Deferred (not in this PR)
The `build_convention_attrs` adoption (routing S1 convention attrs through `zarr_cm.create_many`, the other half of #199) is intentionally **left out**: it only cleanly applies to 1 of the 3 emission sites (the orbit group) and changes on-disk output (CMO ordering), so it belongs in its own reviewable, output-diffed PR rather than bundled with this pure-typing change.
