### PR TITLE
fix(s2): clamp oversized source chunks to sharded 1830px tiles

### DIFF
--- a/src/eopf_geozarr/s2_optimization/s2_multiscale.py
+++ b/src/eopf_geozarr/s2_optimization/s2_multiscale.py
@@ -46,6 +46,15 @@ log = structlog.get_logger()
 
 MultiscalesFlavor = Literal["experimental_multiscales_convention"]
 
+# Default upper bound on chunk dims propagated from the source when copying
+# groups as-is (see the create_original_encoding call site): whole-array
+# source chunks (e.g. cpm_v270 aot/wvp, 10980x10980;
+# EOPF-Explorer/data-pipeline#339) are unusable for tiled serving. The
+# aligned clamp lands on 1830 for the S2 grid sizes — the chunk size the
+# EOPF product spec documents as native S2 tiling (eopf-cpm PSFD 6.7.3,
+# "6x6 chunks").
+MAX_ORIGINAL_CHUNK = 2048
+
 pyramid_levels = {
     0: 10,  # Level 0: 10m (native for b02,b03,b04,b08)
     1: 20,  # Level 1: 20m (native for b05,b06,b07,b11,b12,b8a + all quality)
@@ -337,7 +346,11 @@ def create_multiscale_from_datatree(
                     dataset[data_var].encoding.pop("_FillValue", None)
         else:
             # Non-measurement groups: preserve original encoding
-            encoding = create_original_encoding(dataset)
+            encoding = create_original_encoding(
+                dataset,
+                max_chunk=MAX_ORIGINAL_CHUNK,
+                enable_sharding=enable_sharding,
+            )
 
         ds_out = stream_write_dataset(
             dataset,
@@ -864,8 +877,18 @@ def add_multiscales_metadata_to_parent(
     log.info("Added %s multiscale levels to %s", len(overview_levels), group.path)
 
 
-def create_original_encoding(dataset: xr.Dataset) -> dict[str, XarrayDataArrayEncoding]:
-    """Write a group preserving its original chunking and encoding."""
+def create_original_encoding(
+    dataset: xr.Dataset,
+    *,
+    max_chunk: int,
+    enable_sharding: bool,
+) -> dict[str, XarrayDataArrayEncoding]:
+    """Write a group preserving its original chunking and encoding.
+
+    Source chunk dims larger than ``max_chunk`` are clamped to an aligned
+    size; when ``enable_sharding`` is true, clamped variables get a
+    whole-array shard so each array remains a single storage object.
+    """
     from zarr.codecs import BloscCodec
 
     # Simple encoding that preserves original structure
@@ -880,6 +903,35 @@ def create_original_encoding(dataset: xr.Dataset) -> dict[str, XarrayDataArrayEn
         for key in XARRAY_ENCODING_KEYS - {"compressors", "fill_value"}:
             if key in var_data.encoding:
                 var_encoding[key] = var_data.encoding[key]
+        # Clamp oversized source chunks (e.g. cpm_v270 whole-array aot/wvp)
+        # instead of propagating them into the output store.
+        chunks = var_encoding.get("chunks")
+        if chunks:
+            clamped = tuple(
+                calculate_aligned_chunk_size(dim, max_chunk) if chunk > max_chunk else chunk
+                for dim, chunk in zip(var_data.shape, chunks, strict=True)
+            )
+            if clamped != tuple(chunks):
+                log.info(
+                    "Clamping oversized source chunks for %s: %s -> %s",
+                    var_name,
+                    tuple(chunks),
+                    clamped,
+                )
+                var_encoding["chunks"] = clamped
+                # preferred_chunks hints at the old grid — drop it
+                var_encoding.pop("preferred_chunks", None)
+                if enable_sharding:
+                    # keep one storage object per array (same policy as
+                    # create_measurements_encoding): whole-array shard with
+                    # the clamped chunks as inner tiles
+                    var_encoding["shards"] = calculate_simple_shard_dimensions(
+                        var_data.shape, clamped
+                    )
+                else:
+                    # a source shard shape may no longer be a multiple of the
+                    # clamped chunks
+                    var_encoding.pop("shards", None)
         # Set the zarr-level `fill_value` explicitly rather than letting xarray
         # decide — different xarray versions infer different defaults from the
         # variable's `_FillValue`. See `explicit_fill_value` for the rationale.

--- a/tests/_test_data/geozarr_examples/S2A_MSIL2A_20251008T100041_N0511_R122_T32TQM_20251008T122613.json
+++ b/tests/_test_data/geozarr_examples/S2A_MSIL2A_20251008T100041_N0511_R122_T32TQM_20251008T122613.json
@@ -482,8 +482,8 @@
                         "name": "regular",
                         "configuration": {
                           "chunk_shape": [
-                            10980,
-                            10980
+                            1830,
+                            1830
                           ]
                         }
                       },
@@ -554,8 +554,8 @@
                         "name": "regular",
                         "configuration": {
                           "chunk_shape": [
-                            10980,
-                            10980
+                            1830,
+                            1830
                           ]
                         }
                       },
@@ -626,8 +626,8 @@
                         "name": "regular",
                         "configuration": {
                           "chunk_shape": [
-                            10980,
-                            10980
+                            1830,
+                            1830
                           ]
                         }
                       },
@@ -698,8 +698,8 @@
                         "name": "regular",
                         "configuration": {
                           "chunk_shape": [
-                            10980,
-                            10980
+                            1830,
+                            1830
                           ]
                         }
                       },
@@ -849,8 +849,8 @@
                         "name": "regular",
                         "configuration": {
                           "chunk_shape": [
-                            5490,
-                            5490
+                            1830,
+                            1830
                           ]
                         }
                       },
@@ -921,8 +921,8 @@
                         "name": "regular",
                         "configuration": {
                           "chunk_shape": [
-                            5490,
-                            5490
+                            1830,
+                            1830
                           ]
                         }
                       },
@@ -993,8 +993,8 @@
                         "name": "regular",
                         "configuration": {
                           "chunk_shape": [
-                            5490,
-                            5490
+                            1830,
+                            1830
                           ]
                         }
                       },
@@ -1065,8 +1065,8 @@
                         "name": "regular",
                         "configuration": {
                           "chunk_shape": [
-                            5490,
-                            5490
+                            1830,
+                            1830
                           ]
                         }
                       },
@@ -1137,8 +1137,8 @@
                         "name": "regular",
                         "configuration": {
                           "chunk_shape": [
-                            5490,
-                            5490
+                            1830,
+                            1830
                           ]
                         }
                       },
@@ -1209,8 +1209,8 @@
                         "name": "regular",
                         "configuration": {
                           "chunk_shape": [
-                            5490,
-                            5490
+                            1830,
+                            1830
                           ]
                         }
                       },
@@ -1828,8 +1828,8 @@
                         "name": "regular",
                         "configuration": {
                           "chunk_shape": [
-                            5490,
-                            5490
+                            1830,
+                            1830
                           ]
                         }
                       },
@@ -4114,29 +4114,6 @@
           "zarr_format": 3,
           "node_type": "group",
           "attributes": {
-            "zarr_conventions": [
-              {
-                "uuid": "d35379db-88df-4056-af3a-620245f8e347",
-                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v0.1/schema.json",
-                "spec_url": "https://github.com/zarr-conventions/multiscales/blob/v0.1/README.md",
-                "name": "multiscales",
-                "description": "Multiscale layout of zarr datasets"
-              },
-              {
-                "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
-                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
-                "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
-                "name": "spatial:",
-                "description": "Spatial coordinate information"
-              },
-              {
-                "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
-                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
-                "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
-                "name": "proj:",
-                "description": "Coordinate reference system information for geospatial data"
-              }
-            ],
             "multiscales": {
               "layout": [
                 {
@@ -4239,6 +4216,29 @@
               ],
               "resampling_method": "average"
             },
+            "zarr_conventions": [
+              {
+                "uuid": "d35379db-88df-4056-af3a-620245f8e347",
+                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v0.1/schema.json",
+                "spec_url": "https://github.com/zarr-conventions/multiscales/blob/v0.1/README.md",
+                "name": "multiscales",
+                "description": "Multiscale layout of zarr datasets"
+              },
+              {
+                "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                "name": "spatial:",
+                "description": "Spatial coordinate information"
+              },
+              {
+                "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                "name": "proj:",
+                "description": "Coordinate reference system information for geospatial data"
+              }
+            ],
             "spatial:dimensions": [
               "y",
               "x"
@@ -4273,7 +4273,6 @@
                   10980,
                   10980
                 ],
-                "proj:code": "EPSG:32632",
                 "zarr_conventions": [
                   {
                     "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
@@ -4289,7 +4288,8 @@
                     "name": "proj:",
                     "description": "Coordinate reference system information for geospatial data"
                   }
-                ]
+                ],
+                "proj:code": "EPSG:32632"
               },
               "members": {
                 "b02": {
@@ -4748,7 +4748,6 @@
                   915,
                   915
                 ],
-                "proj:code": "EPSG:32632",
                 "zarr_conventions": [
                   {
                     "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
@@ -4765,6 +4764,7 @@
                     "description": "Coordinate reference system information for geospatial data"
                   }
                 ],
+                "proj:code": "EPSG:32632",
                 "grid_mapping": "spatial_ref"
               },
               "members": {
@@ -5838,7 +5838,6 @@
                   5490,
                   5490
                 ],
-                "proj:code": "EPSG:32632",
                 "zarr_conventions": [
                   {
                     "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
@@ -5854,7 +5853,8 @@
                     "name": "proj:",
                     "description": "Coordinate reference system information for geospatial data"
                   }
-                ]
+                ],
+                "proj:code": "EPSG:32632"
               },
               "members": {
                 "b01": {
@@ -6852,7 +6852,6 @@
                   305,
                   305
                 ],
-                "proj:code": "EPSG:32632",
                 "zarr_conventions": [
                   {
                     "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
@@ -6869,6 +6868,7 @@
                     "description": "Coordinate reference system information for geospatial data"
                   }
                 ],
+                "proj:code": "EPSG:32632",
                 "grid_mapping": "spatial_ref"
               },
               "members": {
@@ -7942,7 +7942,6 @@
                   1830,
                   1830
                 ],
-                "proj:code": "EPSG:32632",
                 "zarr_conventions": [
                   {
                     "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
@@ -7958,7 +7957,8 @@
                     "name": "proj:",
                     "description": "Coordinate reference system information for geospatial data"
                   }
-                ]
+                ],
+                "proj:code": "EPSG:32632"
               },
               "members": {
                 "b01": {
@@ -9033,7 +9033,6 @@
                   152,
                   152
                 ],
-                "proj:code": "EPSG:32632",
                 "zarr_conventions": [
                   {
                     "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
@@ -9050,6 +9049,7 @@
                     "description": "Coordinate reference system information for geospatial data"
                   }
                 ],
+                "proj:code": "EPSG:32632",
                 "grid_mapping": "spatial_ref"
               },
               "members": {
@@ -10137,7 +10137,6 @@
                   10980,
                   10980
                 ],
-                "proj:code": "EPSG:32632",
                 "zarr_conventions": [
                   {
                     "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
@@ -10153,7 +10152,8 @@
                     "name": "proj:",
                     "description": "Coordinate reference system information for geospatial data"
                   }
-                ]
+                ],
+                "proj:code": "EPSG:32632"
               },
               "members": {
                 "aot": {
@@ -10194,8 +10194,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        10980,
-                        10980
+                        1830,
+                        1830
                       ]
                     }
                   },
@@ -10323,8 +10323,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        10980,
-                        10980
+                        1830,
+                        1830
                       ]
                     }
                   },
@@ -10453,7 +10453,6 @@
                   5490,
                   5490
                 ],
-                "proj:code": "EPSG:32632",
                 "zarr_conventions": [
                   {
                     "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
@@ -10469,7 +10468,8 @@
                     "name": "proj:",
                     "description": "Coordinate reference system information for geospatial data"
                   }
-                ]
+                ],
+                "proj:code": "EPSG:32632"
               },
               "members": {
                 "aot": {
@@ -10510,8 +10510,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        5490,
-                        5490
+                        1830,
+                        1830
                       ]
                     }
                   },
@@ -10639,8 +10639,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        5490,
-                        5490
+                        1830,
+                        1830
                       ]
                     }
                   },
@@ -10769,7 +10769,6 @@
                   1830,
                   1830
                 ],
-                "proj:code": "EPSG:32632",
                 "zarr_conventions": [
                   {
                     "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
@@ -10785,7 +10784,8 @@
                     "name": "proj:",
                     "description": "Coordinate reference system information for geospatial data"
                   }
-                ]
+                ],
+                "proj:code": "EPSG:32632"
               },
               "members": {
                 "aot": {
@@ -11092,7 +11092,6 @@
                   10980,
                   10980
                 ],
-                "proj:code": "EPSG:32632",
                 "zarr_conventions": [
                   {
                     "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
@@ -11108,7 +11107,8 @@
                     "name": "proj:",
                     "description": "Coordinate reference system information for geospatial data"
                   }
-                ]
+                ],
+                "proj:code": "EPSG:32632"
               },
               "members": {
                 "b02": {
@@ -11171,8 +11171,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        10980,
-                        10980
+                        1830,
+                        1830
                       ]
                     }
                   },
@@ -11264,8 +11264,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        10980,
-                        10980
+                        1830,
+                        1830
                       ]
                     }
                   },
@@ -11357,8 +11357,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        10980,
-                        10980
+                        1830,
+                        1830
                       ]
                     }
                   },
@@ -11450,8 +11450,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        10980,
-                        10980
+                        1830,
+                        1830
                       ]
                     }
                   },
@@ -11632,7 +11632,6 @@
                   5490,
                   5490
                 ],
-                "proj:code": "EPSG:32632",
                 "zarr_conventions": [
                   {
                     "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
@@ -11648,7 +11647,8 @@
                     "name": "proj:",
                     "description": "Coordinate reference system information for geospatial data"
                   }
-                ]
+                ],
+                "proj:code": "EPSG:32632"
               },
               "members": {
                 "b05": {
@@ -11711,8 +11711,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        5490,
-                        5490
+                        1830,
+                        1830
                       ]
                     }
                   },
@@ -11804,8 +11804,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        5490,
-                        5490
+                        1830,
+                        1830
                       ]
                     }
                   },
@@ -11897,8 +11897,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        5490,
-                        5490
+                        1830,
+                        1830
                       ]
                     }
                   },
@@ -11990,8 +11990,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        5490,
-                        5490
+                        1830,
+                        1830
                       ]
                     }
                   },
@@ -12083,8 +12083,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        5490,
-                        5490
+                        1830,
+                        1830
                       ]
                     }
                   },
@@ -12176,8 +12176,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        5490,
-                        5490
+                        1830,
+                        1830
                       ]
                     }
                   },
@@ -12358,7 +12358,6 @@
                   1830,
                   1830
                 ],
-                "proj:code": "EPSG:32632",
                 "zarr_conventions": [
                   {
                     "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
@@ -12374,7 +12373,8 @@
                     "name": "proj:",
                     "description": "Coordinate reference system information for geospatial data"
                   }
-                ]
+                ],
+                "proj:code": "EPSG:32632"
               },
               "members": {
                 "b01": {
@@ -12812,7 +12812,6 @@
                   5490,
                   5490
                 ],
-                "proj:code": "EPSG:32632",
                 "zarr_conventions": [
                   {
                     "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
@@ -12828,7 +12827,8 @@
                     "name": "proj:",
                     "description": "Coordinate reference system information for geospatial data"
                   }
-                ]
+                ],
+                "proj:code": "EPSG:32632"
               },
               "members": {
                 "band": {
@@ -12900,8 +12900,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        5490,
-                        5490
+                        1830,
+                        1830
                       ]
                     }
                   },
@@ -12972,8 +12972,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        5490,
-                        5490
+                        1830,
+                        1830
                       ]
                     }
                   },

--- a/tests/_test_data/geozarr_examples/S2C_MSIL2A_20250811T112131_N0511_R037_T29TPF_20250811T152216.json
+++ b/tests/_test_data/geozarr_examples/S2C_MSIL2A_20250811T112131_N0511_R037_T29TPF_20250811T152216.json
@@ -482,8 +482,8 @@
                         "name": "regular",
                         "configuration": {
                           "chunk_shape": [
-                            10980,
-                            10980
+                            1830,
+                            1830
                           ]
                         }
                       },
@@ -554,8 +554,8 @@
                         "name": "regular",
                         "configuration": {
                           "chunk_shape": [
-                            10980,
-                            10980
+                            1830,
+                            1830
                           ]
                         }
                       },
@@ -626,8 +626,8 @@
                         "name": "regular",
                         "configuration": {
                           "chunk_shape": [
-                            10980,
-                            10980
+                            1830,
+                            1830
                           ]
                         }
                       },
@@ -698,8 +698,8 @@
                         "name": "regular",
                         "configuration": {
                           "chunk_shape": [
-                            10980,
-                            10980
+                            1830,
+                            1830
                           ]
                         }
                       },
@@ -849,8 +849,8 @@
                         "name": "regular",
                         "configuration": {
                           "chunk_shape": [
-                            5490,
-                            5490
+                            1830,
+                            1830
                           ]
                         }
                       },
@@ -921,8 +921,8 @@
                         "name": "regular",
                         "configuration": {
                           "chunk_shape": [
-                            5490,
-                            5490
+                            1830,
+                            1830
                           ]
                         }
                       },
@@ -993,8 +993,8 @@
                         "name": "regular",
                         "configuration": {
                           "chunk_shape": [
-                            5490,
-                            5490
+                            1830,
+                            1830
                           ]
                         }
                       },
@@ -1065,8 +1065,8 @@
                         "name": "regular",
                         "configuration": {
                           "chunk_shape": [
-                            5490,
-                            5490
+                            1830,
+                            1830
                           ]
                         }
                       },
@@ -1137,8 +1137,8 @@
                         "name": "regular",
                         "configuration": {
                           "chunk_shape": [
-                            5490,
-                            5490
+                            1830,
+                            1830
                           ]
                         }
                       },
@@ -1209,8 +1209,8 @@
                         "name": "regular",
                         "configuration": {
                           "chunk_shape": [
-                            5490,
-                            5490
+                            1830,
+                            1830
                           ]
                         }
                       },
@@ -1828,8 +1828,8 @@
                         "name": "regular",
                         "configuration": {
                           "chunk_shape": [
-                            5490,
-                            5490
+                            1830,
+                            1830
                           ]
                         }
                       },
@@ -4114,29 +4114,6 @@
           "zarr_format": 3,
           "node_type": "group",
           "attributes": {
-            "zarr_conventions": [
-              {
-                "uuid": "d35379db-88df-4056-af3a-620245f8e347",
-                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v0.1/schema.json",
-                "spec_url": "https://github.com/zarr-conventions/multiscales/blob/v0.1/README.md",
-                "name": "multiscales",
-                "description": "Multiscale layout of zarr datasets"
-              },
-              {
-                "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
-                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
-                "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
-                "name": "spatial:",
-                "description": "Spatial coordinate information"
-              },
-              {
-                "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
-                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
-                "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
-                "name": "proj:",
-                "description": "Coordinate reference system information for geospatial data"
-              }
-            ],
             "multiscales": {
               "layout": [
                 {
@@ -4239,6 +4216,29 @@
               ],
               "resampling_method": "average"
             },
+            "zarr_conventions": [
+              {
+                "uuid": "d35379db-88df-4056-af3a-620245f8e347",
+                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v0.1/schema.json",
+                "spec_url": "https://github.com/zarr-conventions/multiscales/blob/v0.1/README.md",
+                "name": "multiscales",
+                "description": "Multiscale layout of zarr datasets"
+              },
+              {
+                "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                "name": "spatial:",
+                "description": "Spatial coordinate information"
+              },
+              {
+                "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                "name": "proj:",
+                "description": "Coordinate reference system information for geospatial data"
+              }
+            ],
             "spatial:dimensions": [
               "y",
               "x"
@@ -4273,7 +4273,6 @@
                   10980,
                   10980
                 ],
-                "proj:code": "EPSG:32629",
                 "zarr_conventions": [
                   {
                     "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
@@ -4289,7 +4288,8 @@
                     "name": "proj:",
                     "description": "Coordinate reference system information for geospatial data"
                   }
-                ]
+                ],
+                "proj:code": "EPSG:32629"
               },
               "members": {
                 "b02": {
@@ -4748,7 +4748,6 @@
                   915,
                   915
                 ],
-                "proj:code": "EPSG:32629",
                 "zarr_conventions": [
                   {
                     "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
@@ -4765,6 +4764,7 @@
                     "description": "Coordinate reference system information for geospatial data"
                   }
                 ],
+                "proj:code": "EPSG:32629",
                 "grid_mapping": "spatial_ref"
               },
               "members": {
@@ -5838,7 +5838,6 @@
                   5490,
                   5490
                 ],
-                "proj:code": "EPSG:32629",
                 "zarr_conventions": [
                   {
                     "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
@@ -5854,7 +5853,8 @@
                     "name": "proj:",
                     "description": "Coordinate reference system information for geospatial data"
                   }
-                ]
+                ],
+                "proj:code": "EPSG:32629"
               },
               "members": {
                 "b01": {
@@ -6852,7 +6852,6 @@
                   305,
                   305
                 ],
-                "proj:code": "EPSG:32629",
                 "zarr_conventions": [
                   {
                     "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
@@ -6869,6 +6868,7 @@
                     "description": "Coordinate reference system information for geospatial data"
                   }
                 ],
+                "proj:code": "EPSG:32629",
                 "grid_mapping": "spatial_ref"
               },
               "members": {
@@ -7942,7 +7942,6 @@
                   1830,
                   1830
                 ],
-                "proj:code": "EPSG:32629",
                 "zarr_conventions": [
                   {
                     "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
@@ -7958,7 +7957,8 @@
                     "name": "proj:",
                     "description": "Coordinate reference system information for geospatial data"
                   }
-                ]
+                ],
+                "proj:code": "EPSG:32629"
               },
               "members": {
                 "b01": {
@@ -9033,7 +9033,6 @@
                   152,
                   152
                 ],
-                "proj:code": "EPSG:32629",
                 "zarr_conventions": [
                   {
                     "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
@@ -9050,6 +9049,7 @@
                     "description": "Coordinate reference system information for geospatial data"
                   }
                 ],
+                "proj:code": "EPSG:32629",
                 "grid_mapping": "spatial_ref"
               },
               "members": {
@@ -10137,7 +10137,6 @@
                   10980,
                   10980
                 ],
-                "proj:code": "EPSG:32629",
                 "zarr_conventions": [
                   {
                     "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
@@ -10153,7 +10152,8 @@
                     "name": "proj:",
                     "description": "Coordinate reference system information for geospatial data"
                   }
-                ]
+                ],
+                "proj:code": "EPSG:32629"
               },
               "members": {
                 "aot": {
@@ -10194,8 +10194,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        10980,
-                        10980
+                        1830,
+                        1830
                       ]
                     }
                   },
@@ -10323,8 +10323,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        10980,
-                        10980
+                        1830,
+                        1830
                       ]
                     }
                   },
@@ -10453,7 +10453,6 @@
                   5490,
                   5490
                 ],
-                "proj:code": "EPSG:32629",
                 "zarr_conventions": [
                   {
                     "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
@@ -10469,7 +10468,8 @@
                     "name": "proj:",
                     "description": "Coordinate reference system information for geospatial data"
                   }
-                ]
+                ],
+                "proj:code": "EPSG:32629"
               },
               "members": {
                 "aot": {
@@ -10510,8 +10510,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        5490,
-                        5490
+                        1830,
+                        1830
                       ]
                     }
                   },
@@ -10639,8 +10639,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        5490,
-                        5490
+                        1830,
+                        1830
                       ]
                     }
                   },
@@ -10769,7 +10769,6 @@
                   1830,
                   1830
                 ],
-                "proj:code": "EPSG:32629",
                 "zarr_conventions": [
                   {
                     "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
@@ -10785,7 +10784,8 @@
                     "name": "proj:",
                     "description": "Coordinate reference system information for geospatial data"
                   }
-                ]
+                ],
+                "proj:code": "EPSG:32629"
               },
               "members": {
                 "aot": {
@@ -11092,7 +11092,6 @@
                   10980,
                   10980
                 ],
-                "proj:code": "EPSG:32629",
                 "zarr_conventions": [
                   {
                     "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
@@ -11108,7 +11107,8 @@
                     "name": "proj:",
                     "description": "Coordinate reference system information for geospatial data"
                   }
-                ]
+                ],
+                "proj:code": "EPSG:32629"
               },
               "members": {
                 "b02": {
@@ -11171,8 +11171,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        10980,
-                        10980
+                        1830,
+                        1830
                       ]
                     }
                   },
@@ -11264,8 +11264,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        10980,
-                        10980
+                        1830,
+                        1830
                       ]
                     }
                   },
@@ -11357,8 +11357,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        10980,
-                        10980
+                        1830,
+                        1830
                       ]
                     }
                   },
@@ -11450,8 +11450,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        10980,
-                        10980
+                        1830,
+                        1830
                       ]
                     }
                   },
@@ -11632,7 +11632,6 @@
                   5490,
                   5490
                 ],
-                "proj:code": "EPSG:32629",
                 "zarr_conventions": [
                   {
                     "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
@@ -11648,7 +11647,8 @@
                     "name": "proj:",
                     "description": "Coordinate reference system information for geospatial data"
                   }
-                ]
+                ],
+                "proj:code": "EPSG:32629"
               },
               "members": {
                 "b05": {
@@ -11711,8 +11711,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        5490,
-                        5490
+                        1830,
+                        1830
                       ]
                     }
                   },
@@ -11804,8 +11804,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        5490,
-                        5490
+                        1830,
+                        1830
                       ]
                     }
                   },
@@ -11897,8 +11897,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        5490,
-                        5490
+                        1830,
+                        1830
                       ]
                     }
                   },
@@ -11990,8 +11990,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        5490,
-                        5490
+                        1830,
+                        1830
                       ]
                     }
                   },
@@ -12083,8 +12083,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        5490,
-                        5490
+                        1830,
+                        1830
                       ]
                     }
                   },
@@ -12176,8 +12176,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        5490,
-                        5490
+                        1830,
+                        1830
                       ]
                     }
                   },
@@ -12358,7 +12358,6 @@
                   1830,
                   1830
                 ],
-                "proj:code": "EPSG:32629",
                 "zarr_conventions": [
                   {
                     "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
@@ -12374,7 +12373,8 @@
                     "name": "proj:",
                     "description": "Coordinate reference system information for geospatial data"
                   }
-                ]
+                ],
+                "proj:code": "EPSG:32629"
               },
               "members": {
                 "b01": {
@@ -12812,7 +12812,6 @@
                   5490,
                   5490
                 ],
-                "proj:code": "EPSG:32629",
                 "zarr_conventions": [
                   {
                     "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
@@ -12828,7 +12827,8 @@
                     "name": "proj:",
                     "description": "Coordinate reference system information for geospatial data"
                   }
-                ]
+                ],
+                "proj:code": "EPSG:32629"
               },
               "members": {
                 "band": {
@@ -12900,8 +12900,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        5490,
-                        5490
+                        1830,
+                        1830
                       ]
                     }
                   },
@@ -12972,8 +12972,8 @@
                     "name": "regular",
                     "configuration": {
                       "chunk_shape": [
-                        5490,
-                        5490
+                        1830,
+                        1830
                       ]
                     }
                   },

--- a/tests/_test_data/optimized_geozarr_examples/S2A_MSIL2A_20251008T100041_N0511_R122_T32TQM_20251008T122613.json
+++ b/tests/_test_data/optimized_geozarr_examples/S2A_MSIL2A_20251008T100041_N0511_R122_T32TQM_20251008T122613.json
@@ -470,17 +470,40 @@
                       },
                       "codecs": [
                         {
-                          "name": "bytes"
-                        },
-                        {
                           "configuration": {
-                            "blocksize": 0,
-                            "clevel": 3,
-                            "cname": "zstd",
-                            "shuffle": "shuffle",
-                            "typesize": 1
+                            "chunk_shape": [
+                              1830,
+                              1830
+                            ],
+                            "codecs": [
+                              {
+                                "name": "bytes"
+                              },
+                              {
+                                "configuration": {
+                                  "blocksize": 0,
+                                  "clevel": 3,
+                                  "cname": "zstd",
+                                  "shuffle": "shuffle",
+                                  "typesize": 1
+                                },
+                                "name": "blosc"
+                              }
+                            ],
+                            "index_codecs": [
+                              {
+                                "configuration": {
+                                  "endian": "little"
+                                },
+                                "name": "bytes"
+                              },
+                              {
+                                "name": "crc32c"
+                              }
+                            ],
+                            "index_location": "end"
                           },
-                          "name": "blosc"
+                          "name": "sharding_indexed"
                         }
                       ],
                       "data_type": "uint8",
@@ -542,17 +565,40 @@
                       },
                       "codecs": [
                         {
-                          "name": "bytes"
-                        },
-                        {
                           "configuration": {
-                            "blocksize": 0,
-                            "clevel": 3,
-                            "cname": "zstd",
-                            "shuffle": "shuffle",
-                            "typesize": 1
+                            "chunk_shape": [
+                              1830,
+                              1830
+                            ],
+                            "codecs": [
+                              {
+                                "name": "bytes"
+                              },
+                              {
+                                "configuration": {
+                                  "blocksize": 0,
+                                  "clevel": 3,
+                                  "cname": "zstd",
+                                  "shuffle": "shuffle",
+                                  "typesize": 1
+                                },
+                                "name": "blosc"
+                              }
+                            ],
+                            "index_codecs": [
+                              {
+                                "configuration": {
+                                  "endian": "little"
+                                },
+                                "name": "bytes"
+                              },
+                              {
+                                "name": "crc32c"
+                              }
+                            ],
+                            "index_location": "end"
                           },
-                          "name": "blosc"
+                          "name": "sharding_indexed"
                         }
                       ],
                       "data_type": "uint8",
@@ -614,17 +660,40 @@
                       },
                       "codecs": [
                         {
-                          "name": "bytes"
-                        },
-                        {
                           "configuration": {
-                            "blocksize": 0,
-                            "clevel": 3,
-                            "cname": "zstd",
-                            "shuffle": "shuffle",
-                            "typesize": 1
+                            "chunk_shape": [
+                              1830,
+                              1830
+                            ],
+                            "codecs": [
+                              {
+                                "name": "bytes"
+                              },
+                              {
+                                "configuration": {
+                                  "blocksize": 0,
+                                  "clevel": 3,
+                                  "cname": "zstd",
+                                  "shuffle": "shuffle",
+                                  "typesize": 1
+                                },
+                                "name": "blosc"
+                              }
+                            ],
+                            "index_codecs": [
+                              {
+                                "configuration": {
+                                  "endian": "little"
+                                },
+                                "name": "bytes"
+                              },
+                              {
+                                "name": "crc32c"
+                              }
+                            ],
+                            "index_location": "end"
                           },
-                          "name": "blosc"
+                          "name": "sharding_indexed"
                         }
                       ],
                       "data_type": "uint8",
@@ -686,17 +755,40 @@
                       },
                       "codecs": [
                         {
-                          "name": "bytes"
-                        },
-                        {
                           "configuration": {
-                            "blocksize": 0,
-                            "clevel": 3,
-                            "cname": "zstd",
-                            "shuffle": "shuffle",
-                            "typesize": 1
+                            "chunk_shape": [
+                              1830,
+                              1830
+                            ],
+                            "codecs": [
+                              {
+                                "name": "bytes"
+                              },
+                              {
+                                "configuration": {
+                                  "blocksize": 0,
+                                  "clevel": 3,
+                                  "cname": "zstd",
+                                  "shuffle": "shuffle",
+                                  "typesize": 1
+                                },
+                                "name": "blosc"
+                              }
+                            ],
+                            "index_codecs": [
+                              {
+                                "configuration": {
+                                  "endian": "little"
+                                },
+                                "name": "bytes"
+                              },
+                              {
+                                "name": "crc32c"
+                              }
+                            ],
+                            "index_location": "end"
                           },
-                          "name": "blosc"
+                          "name": "sharding_indexed"
                         }
                       ],
                       "data_type": "uint8",
@@ -837,17 +929,40 @@
                       },
                       "codecs": [
                         {
-                          "name": "bytes"
-                        },
-                        {
                           "configuration": {
-                            "blocksize": 0,
-                            "clevel": 3,
-                            "cname": "zstd",
-                            "shuffle": "shuffle",
-                            "typesize": 1
+                            "chunk_shape": [
+                              1830,
+                              1830
+                            ],
+                            "codecs": [
+                              {
+                                "name": "bytes"
+                              },
+                              {
+                                "configuration": {
+                                  "blocksize": 0,
+                                  "clevel": 3,
+                                  "cname": "zstd",
+                                  "shuffle": "shuffle",
+                                  "typesize": 1
+                                },
+                                "name": "blosc"
+                              }
+                            ],
+                            "index_codecs": [
+                              {
+                                "configuration": {
+                                  "endian": "little"
+                                },
+                                "name": "bytes"
+                              },
+                              {
+                                "name": "crc32c"
+                              }
+                            ],
+                            "index_location": "end"
                           },
-                          "name": "blosc"
+                          "name": "sharding_indexed"
                         }
                       ],
                       "data_type": "uint8",
@@ -909,17 +1024,40 @@
                       },
                       "codecs": [
                         {
-                          "name": "bytes"
-                        },
-                        {
                           "configuration": {
-                            "blocksize": 0,
-                            "clevel": 3,
-                            "cname": "zstd",
-                            "shuffle": "shuffle",
-                            "typesize": 1
+                            "chunk_shape": [
+                              1830,
+                              1830
+                            ],
+                            "codecs": [
+                              {
+                                "name": "bytes"
+                              },
+                              {
+                                "configuration": {
+                                  "blocksize": 0,
+                                  "clevel": 3,
+                                  "cname": "zstd",
+                                  "shuffle": "shuffle",
+                                  "typesize": 1
+                                },
+                                "name": "blosc"
+                              }
+                            ],
+                            "index_codecs": [
+                              {
+                                "configuration": {
+                                  "endian": "little"
+                                },
+                                "name": "bytes"
+                              },
+                              {
+                                "name": "crc32c"
+                              }
+                            ],
+                            "index_location": "end"
                           },
-                          "name": "blosc"
+                          "name": "sharding_indexed"
                         }
                       ],
                       "data_type": "uint8",
@@ -981,17 +1119,40 @@
                       },
                       "codecs": [
                         {
-                          "name": "bytes"
-                        },
-                        {
                           "configuration": {
-                            "blocksize": 0,
-                            "clevel": 3,
-                            "cname": "zstd",
-                            "shuffle": "shuffle",
-                            "typesize": 1
+                            "chunk_shape": [
+                              1830,
+                              1830
+                            ],
+                            "codecs": [
+                              {
+                                "name": "bytes"
+                              },
+                              {
+                                "configuration": {
+                                  "blocksize": 0,
+                                  "clevel": 3,
+                                  "cname": "zstd",
+                                  "shuffle": "shuffle",
+                                  "typesize": 1
+                                },
+                                "name": "blosc"
+                              }
+                            ],
+                            "index_codecs": [
+                              {
+                                "configuration": {
+                                  "endian": "little"
+                                },
+                                "name": "bytes"
+                              },
+                              {
+                                "name": "crc32c"
+                              }
+                            ],
+                            "index_location": "end"
                           },
-                          "name": "blosc"
+                          "name": "sharding_indexed"
                         }
                       ],
                       "data_type": "uint8",
@@ -1053,17 +1214,40 @@
                       },
                       "codecs": [
                         {
-                          "name": "bytes"
-                        },
-                        {
                           "configuration": {
-                            "blocksize": 0,
-                            "clevel": 3,
-                            "cname": "zstd",
-                            "shuffle": "shuffle",
-                            "typesize": 1
+                            "chunk_shape": [
+                              1830,
+                              1830
+                            ],
+                            "codecs": [
+                              {
+                                "name": "bytes"
+                              },
+                              {
+                                "configuration": {
+                                  "blocksize": 0,
+                                  "clevel": 3,
+                                  "cname": "zstd",
+                                  "shuffle": "shuffle",
+                                  "typesize": 1
+                                },
+                                "name": "blosc"
+                              }
+                            ],
+                            "index_codecs": [
+                              {
+                                "configuration": {
+                                  "endian": "little"
+                                },
+                                "name": "bytes"
+                              },
+                              {
+                                "name": "crc32c"
+                              }
+                            ],
+                            "index_location": "end"
                           },
-                          "name": "blosc"
+                          "name": "sharding_indexed"
                         }
                       ],
                       "data_type": "uint8",
@@ -1125,17 +1309,40 @@
                       },
                       "codecs": [
                         {
-                          "name": "bytes"
-                        },
-                        {
                           "configuration": {
-                            "blocksize": 0,
-                            "clevel": 3,
-                            "cname": "zstd",
-                            "shuffle": "shuffle",
-                            "typesize": 1
+                            "chunk_shape": [
+                              1830,
+                              1830
+                            ],
+                            "codecs": [
+                              {
+                                "name": "bytes"
+                              },
+                              {
+                                "configuration": {
+                                  "blocksize": 0,
+                                  "clevel": 3,
+                                  "cname": "zstd",
+                                  "shuffle": "shuffle",
+                                  "typesize": 1
+                                },
+                                "name": "blosc"
+                              }
+                            ],
+                            "index_codecs": [
+                              {
+                                "configuration": {
+                                  "endian": "little"
+                                },
+                                "name": "bytes"
+                              },
+                              {
+                                "name": "crc32c"
+                              }
+                            ],
+                            "index_location": "end"
                           },
-                          "name": "blosc"
+                          "name": "sharding_indexed"
                         }
                       ],
                       "data_type": "uint8",
@@ -1197,17 +1404,40 @@
                       },
                       "codecs": [
                         {
-                          "name": "bytes"
-                        },
-                        {
                           "configuration": {
-                            "blocksize": 0,
-                            "clevel": 3,
-                            "cname": "zstd",
-                            "shuffle": "shuffle",
-                            "typesize": 1
+                            "chunk_shape": [
+                              1830,
+                              1830
+                            ],
+                            "codecs": [
+                              {
+                                "name": "bytes"
+                              },
+                              {
+                                "configuration": {
+                                  "blocksize": 0,
+                                  "clevel": 3,
+                                  "cname": "zstd",
+                                  "shuffle": "shuffle",
+                                  "typesize": 1
+                                },
+                                "name": "blosc"
+                              }
+                            ],
+                            "index_codecs": [
+                              {
+                                "configuration": {
+                                  "endian": "little"
+                                },
+                                "name": "bytes"
+                              },
+                              {
+                                "name": "crc32c"
+                              }
+                            ],
+                            "index_location": "end"
                           },
-                          "name": "blosc"
+                          "name": "sharding_indexed"
                         }
                       ],
                       "data_type": "uint8",
@@ -1816,17 +2046,40 @@
                       },
                       "codecs": [
                         {
-                          "name": "bytes"
-                        },
-                        {
                           "configuration": {
-                            "blocksize": 0,
-                            "clevel": 3,
-                            "cname": "zstd",
-                            "shuffle": "shuffle",
-                            "typesize": 1
+                            "chunk_shape": [
+                              1830,
+                              1830
+                            ],
+                            "codecs": [
+                              {
+                                "name": "bytes"
+                              },
+                              {
+                                "configuration": {
+                                  "blocksize": 0,
+                                  "clevel": 3,
+                                  "cname": "zstd",
+                                  "shuffle": "shuffle",
+                                  "typesize": 1
+                                },
+                                "name": "blosc"
+                              }
+                            ],
+                            "index_codecs": [
+                              {
+                                "configuration": {
+                                  "endian": "little"
+                                },
+                                "name": "bytes"
+                              },
+                              {
+                                "name": "crc32c"
+                              }
+                            ],
+                            "index_location": "end"
                           },
-                          "name": "blosc"
+                          "name": "sharding_indexed"
                         }
                       ],
                       "data_type": "uint8",
@@ -11634,19 +11887,42 @@
                   "codecs": [
                     {
                       "configuration": {
-                        "endian": "little"
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 2
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 2
-                      },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint16",
@@ -11763,19 +12039,42 @@
                   "codecs": [
                     {
                       "configuration": {
-                        "endian": "little"
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 2
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 2
-                      },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint16",
@@ -11950,19 +12249,42 @@
                   "codecs": [
                     {
                       "configuration": {
-                        "endian": "little"
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 2
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 2
-                      },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint16",
@@ -12079,19 +12401,42 @@
                   "codecs": [
                     {
                       "configuration": {
-                        "endian": "little"
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 2
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 2
-                      },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint16",
@@ -12610,17 +12955,40 @@
                   },
                   "codecs": [
                     {
-                      "name": "bytes"
-                    },
-                    {
                       "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 1
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 1
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint8",
@@ -12703,17 +13071,40 @@
                   },
                   "codecs": [
                     {
-                      "name": "bytes"
-                    },
-                    {
                       "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 1
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 1
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint8",
@@ -12796,17 +13187,40 @@
                   },
                   "codecs": [
                     {
-                      "name": "bytes"
-                    },
-                    {
                       "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 1
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 1
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint8",
@@ -12889,17 +13303,40 @@
                   },
                   "codecs": [
                     {
-                      "name": "bytes"
-                    },
-                    {
                       "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 1
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 1
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint8",
@@ -13150,17 +13587,40 @@
                   },
                   "codecs": [
                     {
-                      "name": "bytes"
-                    },
-                    {
                       "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 1
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 1
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint8",
@@ -13243,17 +13703,40 @@
                   },
                   "codecs": [
                     {
-                      "name": "bytes"
-                    },
-                    {
                       "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 1
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 1
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint8",
@@ -13336,17 +13819,40 @@
                   },
                   "codecs": [
                     {
-                      "name": "bytes"
-                    },
-                    {
                       "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 1
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 1
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint8",
@@ -13429,17 +13935,40 @@
                   },
                   "codecs": [
                     {
-                      "name": "bytes"
-                    },
-                    {
                       "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 1
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 1
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint8",
@@ -13522,17 +14051,40 @@
                   },
                   "codecs": [
                     {
-                      "name": "bytes"
-                    },
-                    {
                       "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 1
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 1
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint8",
@@ -13615,17 +14167,40 @@
                   },
                   "codecs": [
                     {
-                      "name": "bytes"
-                    },
-                    {
                       "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 1
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 1
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint8",
@@ -14339,17 +14914,40 @@
                   },
                   "codecs": [
                     {
-                      "name": "bytes"
-                    },
-                    {
                       "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 1
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 1
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint8",
@@ -14411,17 +15009,40 @@
                   },
                   "codecs": [
                     {
-                      "name": "bytes"
-                    },
-                    {
                       "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 1
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 1
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint8",

--- a/tests/_test_data/optimized_geozarr_examples/S2C_MSIL2A_20250811T112131_N0511_R037_T29TPF_20250811T152216.json
+++ b/tests/_test_data/optimized_geozarr_examples/S2C_MSIL2A_20250811T112131_N0511_R037_T29TPF_20250811T152216.json
@@ -470,17 +470,40 @@
                       },
                       "codecs": [
                         {
-                          "name": "bytes"
-                        },
-                        {
                           "configuration": {
-                            "blocksize": 0,
-                            "clevel": 3,
-                            "cname": "zstd",
-                            "shuffle": "shuffle",
-                            "typesize": 1
+                            "chunk_shape": [
+                              1830,
+                              1830
+                            ],
+                            "codecs": [
+                              {
+                                "name": "bytes"
+                              },
+                              {
+                                "configuration": {
+                                  "blocksize": 0,
+                                  "clevel": 3,
+                                  "cname": "zstd",
+                                  "shuffle": "shuffle",
+                                  "typesize": 1
+                                },
+                                "name": "blosc"
+                              }
+                            ],
+                            "index_codecs": [
+                              {
+                                "configuration": {
+                                  "endian": "little"
+                                },
+                                "name": "bytes"
+                              },
+                              {
+                                "name": "crc32c"
+                              }
+                            ],
+                            "index_location": "end"
                           },
-                          "name": "blosc"
+                          "name": "sharding_indexed"
                         }
                       ],
                       "data_type": "uint8",
@@ -542,17 +565,40 @@
                       },
                       "codecs": [
                         {
-                          "name": "bytes"
-                        },
-                        {
                           "configuration": {
-                            "blocksize": 0,
-                            "clevel": 3,
-                            "cname": "zstd",
-                            "shuffle": "shuffle",
-                            "typesize": 1
+                            "chunk_shape": [
+                              1830,
+                              1830
+                            ],
+                            "codecs": [
+                              {
+                                "name": "bytes"
+                              },
+                              {
+                                "configuration": {
+                                  "blocksize": 0,
+                                  "clevel": 3,
+                                  "cname": "zstd",
+                                  "shuffle": "shuffle",
+                                  "typesize": 1
+                                },
+                                "name": "blosc"
+                              }
+                            ],
+                            "index_codecs": [
+                              {
+                                "configuration": {
+                                  "endian": "little"
+                                },
+                                "name": "bytes"
+                              },
+                              {
+                                "name": "crc32c"
+                              }
+                            ],
+                            "index_location": "end"
                           },
-                          "name": "blosc"
+                          "name": "sharding_indexed"
                         }
                       ],
                       "data_type": "uint8",
@@ -614,17 +660,40 @@
                       },
                       "codecs": [
                         {
-                          "name": "bytes"
-                        },
-                        {
                           "configuration": {
-                            "blocksize": 0,
-                            "clevel": 3,
-                            "cname": "zstd",
-                            "shuffle": "shuffle",
-                            "typesize": 1
+                            "chunk_shape": [
+                              1830,
+                              1830
+                            ],
+                            "codecs": [
+                              {
+                                "name": "bytes"
+                              },
+                              {
+                                "configuration": {
+                                  "blocksize": 0,
+                                  "clevel": 3,
+                                  "cname": "zstd",
+                                  "shuffle": "shuffle",
+                                  "typesize": 1
+                                },
+                                "name": "blosc"
+                              }
+                            ],
+                            "index_codecs": [
+                              {
+                                "configuration": {
+                                  "endian": "little"
+                                },
+                                "name": "bytes"
+                              },
+                              {
+                                "name": "crc32c"
+                              }
+                            ],
+                            "index_location": "end"
                           },
-                          "name": "blosc"
+                          "name": "sharding_indexed"
                         }
                       ],
                       "data_type": "uint8",
@@ -686,17 +755,40 @@
                       },
                       "codecs": [
                         {
-                          "name": "bytes"
-                        },
-                        {
                           "configuration": {
-                            "blocksize": 0,
-                            "clevel": 3,
-                            "cname": "zstd",
-                            "shuffle": "shuffle",
-                            "typesize": 1
+                            "chunk_shape": [
+                              1830,
+                              1830
+                            ],
+                            "codecs": [
+                              {
+                                "name": "bytes"
+                              },
+                              {
+                                "configuration": {
+                                  "blocksize": 0,
+                                  "clevel": 3,
+                                  "cname": "zstd",
+                                  "shuffle": "shuffle",
+                                  "typesize": 1
+                                },
+                                "name": "blosc"
+                              }
+                            ],
+                            "index_codecs": [
+                              {
+                                "configuration": {
+                                  "endian": "little"
+                                },
+                                "name": "bytes"
+                              },
+                              {
+                                "name": "crc32c"
+                              }
+                            ],
+                            "index_location": "end"
                           },
-                          "name": "blosc"
+                          "name": "sharding_indexed"
                         }
                       ],
                       "data_type": "uint8",
@@ -837,17 +929,40 @@
                       },
                       "codecs": [
                         {
-                          "name": "bytes"
-                        },
-                        {
                           "configuration": {
-                            "blocksize": 0,
-                            "clevel": 3,
-                            "cname": "zstd",
-                            "shuffle": "shuffle",
-                            "typesize": 1
+                            "chunk_shape": [
+                              1830,
+                              1830
+                            ],
+                            "codecs": [
+                              {
+                                "name": "bytes"
+                              },
+                              {
+                                "configuration": {
+                                  "blocksize": 0,
+                                  "clevel": 3,
+                                  "cname": "zstd",
+                                  "shuffle": "shuffle",
+                                  "typesize": 1
+                                },
+                                "name": "blosc"
+                              }
+                            ],
+                            "index_codecs": [
+                              {
+                                "configuration": {
+                                  "endian": "little"
+                                },
+                                "name": "bytes"
+                              },
+                              {
+                                "name": "crc32c"
+                              }
+                            ],
+                            "index_location": "end"
                           },
-                          "name": "blosc"
+                          "name": "sharding_indexed"
                         }
                       ],
                       "data_type": "uint8",
@@ -909,17 +1024,40 @@
                       },
                       "codecs": [
                         {
-                          "name": "bytes"
-                        },
-                        {
                           "configuration": {
-                            "blocksize": 0,
-                            "clevel": 3,
-                            "cname": "zstd",
-                            "shuffle": "shuffle",
-                            "typesize": 1
+                            "chunk_shape": [
+                              1830,
+                              1830
+                            ],
+                            "codecs": [
+                              {
+                                "name": "bytes"
+                              },
+                              {
+                                "configuration": {
+                                  "blocksize": 0,
+                                  "clevel": 3,
+                                  "cname": "zstd",
+                                  "shuffle": "shuffle",
+                                  "typesize": 1
+                                },
+                                "name": "blosc"
+                              }
+                            ],
+                            "index_codecs": [
+                              {
+                                "configuration": {
+                                  "endian": "little"
+                                },
+                                "name": "bytes"
+                              },
+                              {
+                                "name": "crc32c"
+                              }
+                            ],
+                            "index_location": "end"
                           },
-                          "name": "blosc"
+                          "name": "sharding_indexed"
                         }
                       ],
                       "data_type": "uint8",
@@ -981,17 +1119,40 @@
                       },
                       "codecs": [
                         {
-                          "name": "bytes"
-                        },
-                        {
                           "configuration": {
-                            "blocksize": 0,
-                            "clevel": 3,
-                            "cname": "zstd",
-                            "shuffle": "shuffle",
-                            "typesize": 1
+                            "chunk_shape": [
+                              1830,
+                              1830
+                            ],
+                            "codecs": [
+                              {
+                                "name": "bytes"
+                              },
+                              {
+                                "configuration": {
+                                  "blocksize": 0,
+                                  "clevel": 3,
+                                  "cname": "zstd",
+                                  "shuffle": "shuffle",
+                                  "typesize": 1
+                                },
+                                "name": "blosc"
+                              }
+                            ],
+                            "index_codecs": [
+                              {
+                                "configuration": {
+                                  "endian": "little"
+                                },
+                                "name": "bytes"
+                              },
+                              {
+                                "name": "crc32c"
+                              }
+                            ],
+                            "index_location": "end"
                           },
-                          "name": "blosc"
+                          "name": "sharding_indexed"
                         }
                       ],
                       "data_type": "uint8",
@@ -1053,17 +1214,40 @@
                       },
                       "codecs": [
                         {
-                          "name": "bytes"
-                        },
-                        {
                           "configuration": {
-                            "blocksize": 0,
-                            "clevel": 3,
-                            "cname": "zstd",
-                            "shuffle": "shuffle",
-                            "typesize": 1
+                            "chunk_shape": [
+                              1830,
+                              1830
+                            ],
+                            "codecs": [
+                              {
+                                "name": "bytes"
+                              },
+                              {
+                                "configuration": {
+                                  "blocksize": 0,
+                                  "clevel": 3,
+                                  "cname": "zstd",
+                                  "shuffle": "shuffle",
+                                  "typesize": 1
+                                },
+                                "name": "blosc"
+                              }
+                            ],
+                            "index_codecs": [
+                              {
+                                "configuration": {
+                                  "endian": "little"
+                                },
+                                "name": "bytes"
+                              },
+                              {
+                                "name": "crc32c"
+                              }
+                            ],
+                            "index_location": "end"
                           },
-                          "name": "blosc"
+                          "name": "sharding_indexed"
                         }
                       ],
                       "data_type": "uint8",
@@ -1125,17 +1309,40 @@
                       },
                       "codecs": [
                         {
-                          "name": "bytes"
-                        },
-                        {
                           "configuration": {
-                            "blocksize": 0,
-                            "clevel": 3,
-                            "cname": "zstd",
-                            "shuffle": "shuffle",
-                            "typesize": 1
+                            "chunk_shape": [
+                              1830,
+                              1830
+                            ],
+                            "codecs": [
+                              {
+                                "name": "bytes"
+                              },
+                              {
+                                "configuration": {
+                                  "blocksize": 0,
+                                  "clevel": 3,
+                                  "cname": "zstd",
+                                  "shuffle": "shuffle",
+                                  "typesize": 1
+                                },
+                                "name": "blosc"
+                              }
+                            ],
+                            "index_codecs": [
+                              {
+                                "configuration": {
+                                  "endian": "little"
+                                },
+                                "name": "bytes"
+                              },
+                              {
+                                "name": "crc32c"
+                              }
+                            ],
+                            "index_location": "end"
                           },
-                          "name": "blosc"
+                          "name": "sharding_indexed"
                         }
                       ],
                       "data_type": "uint8",
@@ -1197,17 +1404,40 @@
                       },
                       "codecs": [
                         {
-                          "name": "bytes"
-                        },
-                        {
                           "configuration": {
-                            "blocksize": 0,
-                            "clevel": 3,
-                            "cname": "zstd",
-                            "shuffle": "shuffle",
-                            "typesize": 1
+                            "chunk_shape": [
+                              1830,
+                              1830
+                            ],
+                            "codecs": [
+                              {
+                                "name": "bytes"
+                              },
+                              {
+                                "configuration": {
+                                  "blocksize": 0,
+                                  "clevel": 3,
+                                  "cname": "zstd",
+                                  "shuffle": "shuffle",
+                                  "typesize": 1
+                                },
+                                "name": "blosc"
+                              }
+                            ],
+                            "index_codecs": [
+                              {
+                                "configuration": {
+                                  "endian": "little"
+                                },
+                                "name": "bytes"
+                              },
+                              {
+                                "name": "crc32c"
+                              }
+                            ],
+                            "index_location": "end"
                           },
-                          "name": "blosc"
+                          "name": "sharding_indexed"
                         }
                       ],
                       "data_type": "uint8",
@@ -1816,17 +2046,40 @@
                       },
                       "codecs": [
                         {
-                          "name": "bytes"
-                        },
-                        {
                           "configuration": {
-                            "blocksize": 0,
-                            "clevel": 3,
-                            "cname": "zstd",
-                            "shuffle": "shuffle",
-                            "typesize": 1
+                            "chunk_shape": [
+                              1830,
+                              1830
+                            ],
+                            "codecs": [
+                              {
+                                "name": "bytes"
+                              },
+                              {
+                                "configuration": {
+                                  "blocksize": 0,
+                                  "clevel": 3,
+                                  "cname": "zstd",
+                                  "shuffle": "shuffle",
+                                  "typesize": 1
+                                },
+                                "name": "blosc"
+                              }
+                            ],
+                            "index_codecs": [
+                              {
+                                "configuration": {
+                                  "endian": "little"
+                                },
+                                "name": "bytes"
+                              },
+                              {
+                                "name": "crc32c"
+                              }
+                            ],
+                            "index_location": "end"
                           },
-                          "name": "blosc"
+                          "name": "sharding_indexed"
                         }
                       ],
                       "data_type": "uint8",
@@ -11634,19 +11887,42 @@
                   "codecs": [
                     {
                       "configuration": {
-                        "endian": "little"
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 2
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 2
-                      },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint16",
@@ -11763,19 +12039,42 @@
                   "codecs": [
                     {
                       "configuration": {
-                        "endian": "little"
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 2
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 2
-                      },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint16",
@@ -11950,19 +12249,42 @@
                   "codecs": [
                     {
                       "configuration": {
-                        "endian": "little"
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 2
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 2
-                      },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint16",
@@ -12079,19 +12401,42 @@
                   "codecs": [
                     {
                       "configuration": {
-                        "endian": "little"
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 2
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 2
-                      },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint16",
@@ -12610,17 +12955,40 @@
                   },
                   "codecs": [
                     {
-                      "name": "bytes"
-                    },
-                    {
                       "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 1
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 1
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint8",
@@ -12703,17 +13071,40 @@
                   },
                   "codecs": [
                     {
-                      "name": "bytes"
-                    },
-                    {
                       "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 1
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 1
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint8",
@@ -12796,17 +13187,40 @@
                   },
                   "codecs": [
                     {
-                      "name": "bytes"
-                    },
-                    {
                       "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 1
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 1
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint8",
@@ -12889,17 +13303,40 @@
                   },
                   "codecs": [
                     {
-                      "name": "bytes"
-                    },
-                    {
                       "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 1
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 1
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint8",
@@ -13150,17 +13587,40 @@
                   },
                   "codecs": [
                     {
-                      "name": "bytes"
-                    },
-                    {
                       "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 1
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 1
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint8",
@@ -13243,17 +13703,40 @@
                   },
                   "codecs": [
                     {
-                      "name": "bytes"
-                    },
-                    {
                       "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 1
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 1
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint8",
@@ -13336,17 +13819,40 @@
                   },
                   "codecs": [
                     {
-                      "name": "bytes"
-                    },
-                    {
                       "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 1
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 1
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint8",
@@ -13429,17 +13935,40 @@
                   },
                   "codecs": [
                     {
-                      "name": "bytes"
-                    },
-                    {
                       "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 1
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 1
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint8",
@@ -13522,17 +14051,40 @@
                   },
                   "codecs": [
                     {
-                      "name": "bytes"
-                    },
-                    {
                       "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 1
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 1
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint8",
@@ -13615,17 +14167,40 @@
                   },
                   "codecs": [
                     {
-                      "name": "bytes"
-                    },
-                    {
                       "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 1
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 1
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint8",
@@ -14339,17 +14914,40 @@
                   },
                   "codecs": [
                     {
-                      "name": "bytes"
-                    },
-                    {
                       "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 1
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 1
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint8",
@@ -14411,17 +15009,40 @@
                   },
                   "codecs": [
                     {
-                      "name": "bytes"
-                    },
-                    {
                       "configuration": {
-                        "blocksize": 0,
-                        "clevel": 3,
-                        "cname": "zstd",
-                        "shuffle": "shuffle",
-                        "typesize": 1
+                        "chunk_shape": [
+                          1830,
+                          1830
+                        ],
+                        "codecs": [
+                          {
+                            "name": "bytes"
+                          },
+                          {
+                            "configuration": {
+                              "blocksize": 0,
+                              "clevel": 3,
+                              "cname": "zstd",
+                              "shuffle": "shuffle",
+                              "typesize": 1
+                            },
+                            "name": "blosc"
+                          }
+                        ],
+                        "index_codecs": [
+                          {
+                            "configuration": {
+                              "endian": "little"
+                            },
+                            "name": "bytes"
+                          },
+                          {
+                            "name": "crc32c"
+                          }
+                        ],
+                        "index_location": "end"
                       },
-                      "name": "blosc"
+                      "name": "sharding_indexed"
                     }
                   ],
                   "data_type": "uint8",

--- a/tests/test_s2_multiscale.py
+++ b/tests/test_s2_multiscale.py
@@ -9,6 +9,7 @@ from itertools import pairwise
 from pathlib import Path
 from unittest.mock import patch
 
+import dask.array
 import numpy as np
 import pytest
 import xarray as xr
@@ -21,6 +22,7 @@ from zarr.core.dtype import Int16
 from zarr.core.metadata import ArrayV3Metadata
 
 from eopf_geozarr.s2_optimization.s2_multiscale import (
+    MAX_ORIGINAL_CHUNK,
     _coarsen_variable,
     add_multiscales_metadata_to_parent,
     calculate_aligned_chunk_size,
@@ -28,6 +30,7 @@ from eopf_geozarr.s2_optimization.s2_multiscale import (
     create_downsampled_resolution_group,
     create_measurements_encoding,
     create_multiscale_from_datatree,
+    create_original_encoding,
     inject_missing_bands,
 )
 
@@ -235,6 +238,80 @@ def test_create_measurements_encoding_time_chunking(sample_dataset: xr.Dataset) 
             chunks = encoding[str(var_name)].get("chunks")
             assert chunks is not None
             assert chunks[0] == 1  # Time dimension should be chunked to 1
+
+
+def _lazy_var(shape: tuple[int, ...], encoding_chunks: tuple[int, ...]) -> xr.DataArray:
+    """A lazy (dask) variable carrying source zarr chunk metadata in encoding."""
+    data = dask.array.zeros(shape, chunks=encoding_chunks, dtype="f4")
+    var = xr.DataArray(data, dims=["y", "x"])
+    var.encoding["chunks"] = encoding_chunks
+    return var
+
+
+def test_create_original_encoding_clamps_whole_array_chunks() -> None:
+    """v270-era products store quality/atmosphere aot/wvp as ONE whole-array
+    chunk (EOPF-Explorer/data-pipeline#339); the output encoding must not
+    propagate a 10980x10980 (~241 MB raw uint16) chunk. The clamp lands on
+    1830, the EOPF-documented native S2 tiling (eopf-cpm PSFD 6.7.3,
+    "6x6 chunks"). With sharding enabled the clamped
+    chunks become inner tiles of a whole-array shard, so each array is still
+    a single storage object.
+    """
+    encoding_r10m = create_original_encoding(
+        xr.Dataset({"aot": _lazy_var((10980, 10980), (10980, 10980))}),
+        max_chunk=MAX_ORIGINAL_CHUNK,
+        enable_sharding=True,
+    )
+    encoding_r20m = create_original_encoding(
+        xr.Dataset({"wvp": _lazy_var((5490, 5490), (5490, 5490))}),
+        max_chunk=MAX_ORIGINAL_CHUNK,
+        enable_sharding=True,
+    )
+    assert encoding_r10m["aot"].get("chunks") == (1830, 1830)
+    assert encoding_r10m["aot"].get("shards") == (10980, 10980)
+    assert encoding_r20m["wvp"].get("chunks") == (1830, 1830)
+    assert encoding_r20m["wvp"].get("shards") == (5490, 5490)
+
+
+def test_create_original_encoding_preserves_reasonable_chunks() -> None:
+    encoding_scl = create_original_encoding(
+        xr.Dataset({"scl": _lazy_var((5490, 5490), (1830, 1830))}),
+        max_chunk=MAX_ORIGINAL_CHUNK,
+        enable_sharding=True,
+    )
+    encoding_small = create_original_encoding(
+        xr.Dataset({"small": _lazy_var((384, 384), (384, 384))}),
+        max_chunk=MAX_ORIGINAL_CHUNK,
+        enable_sharding=True,
+    )
+    assert encoding_scl["scl"].get("chunks") == (1830, 1830)
+    assert "shards" not in encoding_scl["scl"]
+    assert encoding_small["small"].get("chunks") == (384, 384)
+    assert "shards" not in encoding_small["small"]
+
+
+def test_create_original_encoding_drops_stale_companions_on_clamp() -> None:
+    var = _lazy_var((10980, 10980), (10980, 10980))
+    var.encoding["preferred_chunks"] = {"y": 10980, "x": 10980}
+    var.encoding["shards"] = (10980, 10980)
+    dataset = xr.Dataset({"aot": var})
+    encoding = create_original_encoding(
+        dataset, max_chunk=MAX_ORIGINAL_CHUNK, enable_sharding=False
+    )
+    assert encoding["aot"].get("chunks") == (1830, 1830)
+    assert "preferred_chunks" not in encoding["aot"]
+    assert "shards" not in encoding["aot"]
+
+
+def test_create_original_encoding_clamps_only_spatial_dims_of_3d_vars() -> None:
+    data = dask.array.zeros((1, 10980, 10980), chunks=(1, 10980, 10980), dtype="f4")
+    var = xr.DataArray(data, dims=["time", "y", "x"])
+    var.encoding["chunks"] = (1, 10980, 10980)
+    encoding = create_original_encoding(
+        xr.Dataset({"aot": var}), max_chunk=MAX_ORIGINAL_CHUNK, enable_sharding=True
+    )
+    assert encoding["aot"].get("chunks") == (1, 1830, 1830)
+    assert encoding["aot"].get("shards") == (1, 10980, 10980)
 
 
 def test_calculate_aligned_chunk_size() -> None:


### PR DESCRIPTION
Mitigates the output-side half of EOPF-Explorer/data-pipeline#339; split out of #220 to separate concerns (the source-read fix stays there). Some source products store `quality/atmosphere` `aot`/`wvp` as one whole-array 10980×10980 chunk (~482 MB raw), and `create_original_encoding` propagated that layout verbatim into converted outputs. Oversized chunks are now clamped to 1830×1830 inner tiles (the PSFD §6.7.3 native S2 tiling) inside a whole-array shard, so each array remains a single storage object — per @d-v-b's review on #220 (single-chunk/file policy, explicit `max_chunk`/`enable_sharding` parameters instead of a magic global). Snapshot fixtures regenerated.

Draft pending #222 (output chunk-layout policy discussion).

**For reviewers:** clamped arrays keep their whole-array `chunk_shape` but gain a `sharding_indexed` codec with 1830×1830 inner tiles; the rest of the fixture diff is key-reordering noise from regeneration (the comparison is order-insensitive).

## Author attestation

- [ ] I am a human, these are my changes, and I have reviewed and understood every change and can explain why each is correct.

Analysis, implementation, and tests were AI-assisted (Claude Code); the PR was opened by Claude Code at the author's request — attestation checkbox left for the author to tick after their own review.

