### PR TITLE
fix(docs): update documentation to reflect GeoZarr conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@ GeoZarr compliant data model for EOPF (Earth Observation Processing Framework) d
 
 ## Overview
 
-This library provides tools to convert EOPF datasets to GeoZarr-spec 0.4 compliant format while maintaining native projections and using /2 downsampling logic for multiscale support.
+This library provides tools to convert EOPF datasets to GeoZarr format while maintaining native projections and using /2 downsampling logic for multiscale support.
+
+GeoZarr is a set of modular [Zarr conventions](https://geozarr.org/conventions) developed by the OGC GeoZarr Standards Working Group. The conventions are still in development and GeoZarr V1 is not released yet (see the [GeoZarr roadmap](https://geozarr.org/roadmap)). This library therefore targets the current conventions, not a numbered specification release. See the [GeoZarr Mini Spec](docs/geozarr-minispec.md) for the exact subset it implements.
 
 ## Key Features
 
-- **GeoZarr Specification Compliance**: Full compliance with GeoZarr spec 0.4
+- **GeoZarr Conventions**: Implements the `multiscales`, `geo-proj` and `spatial` conventions
 - **Native CRS Preservation**: No reprojection to TMS, maintains original coordinate reference systems
 - **Multiscale Support**: COG-style /2 downsampling with overview levels as children groups
 - **CF Conventions**: Proper CF standard names and grid_mapping attributes
@@ -24,7 +26,7 @@ This library provides tools to convert EOPF datasets to GeoZarr-spec 0.4 complia
 - `grid_mapping` attributes referencing CF grid_mapping variables
 - `GeoTransform` attributes in grid_mapping variables
 - Proper multiscales metadata structure
-- Native CRS tile matrix sets
+- Native CRS preservation
 
 ## Installation
 
@@ -216,7 +218,7 @@ dt_geozarr = create_geozarr_dataset(
 
 #### `create_geozarr_dataset`
 
-Create a GeoZarr-spec 0.4 compliant dataset from EOPF data.
+Create a GeoZarr compliant dataset from EOPF data.
 
 **Parameters:**
 
@@ -291,12 +293,12 @@ The library is organized into the following modules:
 
 ## GeoZarr Specification Compliance
 
-This library implements the GeoZarr specification 0.4 with the following key requirements:
+This library implements the GeoZarr conventions with the following key requirements:
 
 1. **Array Dimensions**: All arrays must have `_ARRAY_DIMENSIONS` attributes
 2. **CF Standard Names**: All variables must have CF-compliant `standard_name` attributes
 3. **Grid Mapping**: Data variables must reference CF grid_mapping variables via `grid_mapping` attributes
-4. **Multiscales Structure**: Overview levels are stored as children groups with proper tile matrix metadata
+4. **Multiscales Structure**: Overview levels are stored as children groups with proper `multiscales` convention metadata
 5. **Native CRS**: Coordinate reference systems are preserved without reprojection
 
 ## Contributing to GeoZarr Specification

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@ This document describes the architecture and design principles of the EOPF GeoZa
 
 ## Overview
 
-The EOPF GeoZarr library is designed to convert EOPF (Earth Observation Processing Framework) datasets to GeoZarr-spec 0.4 compliant format while maintaining scientific accuracy and optimizing performance.
+The EOPF GeoZarr library is designed to convert EOPF (Earth Observation Processing Framework) datasets to GeoZarr format while maintaining scientific accuracy and optimizing performance.
 
 This implementation follows our [GeoZarr Mini Spec](geozarr-minispec.md), which defines the specific subset of the GeoZarr specification that this library implements, including implementation-specific details for chunking, CF compliance, and multiscale dataset organization.
 

--- a/docs/converter.md
+++ b/docs/converter.md
@@ -1,6 +1,6 @@
 # Using the GeoZarr Converter
 
-The GeoZarr converter provides tools to transform EOPF datasets into GeoZarr-spec 0.4 compliant format. This guide explains how to use the converter effectively.
+The GeoZarr converter provides tools to transform EOPF datasets into GeoZarr format. This guide explains how to use the converter effectively.
 
 ## Command Line Interface
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,13 +6,13 @@ Common questions and solutions for using the EOPF GeoZarr library.
 
 ### What is EOPF GeoZarr?
 
-EOPF GeoZarr is a Python library that converts EOPF (Earth Observation Processing Framework) datasets to GeoZarr-spec 0.4 compliant format. It maintains scientific accuracy while optimizing for cloud-native workflows and performance.
+EOPF GeoZarr is a Python library that converts EOPF (Earth Observation Processing Framework) datasets to GeoZarr format. It maintains scientific accuracy while optimizing for cloud-native workflows and performance.
 
 ### What makes this different from standard Zarr?
 
-GeoZarr is a specification that extends Zarr with geospatial metadata standards. Our library specifically:
+GeoZarr is a set of modular [Zarr conventions](https://geozarr.org/conventions) that extend Zarr with geospatial metadata standards. The conventions are still in development, and GeoZarr V1 is not released yet (see the [GeoZarr roadmap](https://geozarr.org/roadmap)). Our library specifically:
 
-- Ensures GeoZarr 0.4 specification compliance
+- Applies the GeoZarr conventions (`multiscales`, `geo-proj`, `spatial`)
 - Preserves native coordinate reference systems
 - Creates multiscale pyramids for efficient visualization
 - Maintains CF conventions for scientific interoperability

--- a/docs/geozarr-minispec.md
+++ b/docs/geozarr-minispec.md
@@ -4,7 +4,7 @@ This document specifies the GeoZarr model used in this repository. It is a "mini
 
 GeoZarr is a set of modular, composable [Zarr conventions](https://geozarr.org/conventions) for storing multidimensional georeferenced grids. The specification is developed by the [OGC GeoZarr Standards Working Group](https://geozarr.org/) and is on track for Architecture Board review in summer 2026 (see [roadmap](https://geozarr.org/roadmap)). All three core conventions are currently at **Proposal** maturity, targeting **Candidate** status (3+ independent implementations) for GeoZarr V1.
 
-> **Evolution note**: Earlier versions of this mini-spec documented a "V0 maximalist" approach based on GeoZarr 0.4 (TileMatrixSet multiscales, mandatory CF conventions, `grid_mapping` 0D arrays). That approach has been superseded by the modular Zarr Conventions described below, which were established at the Zarr Summit in Rome (December 2025) and are the basis of this implementation since v1.0.
+> **Evolution note**: Earlier versions of this mini-spec documented a "V0 maximalist" approach based on an early GeoZarr draft (TileMatrixSet multiscales, mandatory CF conventions, `grid_mapping` 0D arrays). That approach has been superseded by the modular Zarr Conventions described below, which were established at the Zarr Summit in Rome (December 2025) and are the basis of this implementation since v1.0.
 
 ## Relationship to Other Documentation
 

--- a/docs/geozarr-minispec.md
+++ b/docs/geozarr-minispec.md
@@ -4,7 +4,7 @@ This document specifies the GeoZarr model used in this repository. It is a "mini
 
 GeoZarr is a set of modular, composable [Zarr conventions](https://geozarr.org/conventions) for storing multidimensional georeferenced grids. The specification is developed by the [OGC GeoZarr Standards Working Group](https://geozarr.org/) and is on track for Architecture Board review in summer 2026 (see [roadmap](https://geozarr.org/roadmap)). All three core conventions are currently at **Proposal** maturity, targeting **Candidate** status (3+ independent implementations) for GeoZarr V1.
 
-> **Evolution note**: Earlier versions of this mini-spec documented a "V0 maximalist" approach based on an early GeoZarr draft (TileMatrixSet multiscales, mandatory CF conventions, `grid_mapping` 0D arrays). That approach has been superseded by the modular Zarr Conventions described below, which were established at the Zarr Summit in Rome (December 2025) and are the basis of this implementation since v1.0.
+> **Evolution note**: Earlier versions of this mini-spec documented a "V0 maximalist" approach based on an early GeoZarr 0.4 draft (TileMatrixSet multiscales, mandatory CF conventions, `grid_mapping` 0D arrays). That approach has been superseded by the modular Zarr Conventions described below, which were established at the Zarr Summit in Rome (December 2025) and are the basis of this implementation since v1.0.
 
 ## Relationship to Other Documentation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # EOPF GeoZarr Documentation
 
-Welcome to the EOPF GeoZarr library documentation. This library provides tools to convert EOPF (Earth Observation Processing Framework) datasets to GeoZarr-spec 0.4 compliant format while maintaining scientific accuracy and optimizing for cloud-native workflows.
+Welcome to the EOPF GeoZarr library documentation. This library provides tools to convert EOPF (Earth Observation Processing Framework) datasets to GeoZarr format while maintaining scientific accuracy and optimizing for cloud-native workflows.
 
 ## Quick Navigation
 
@@ -29,7 +29,7 @@ The EOPF GeoZarr library bridges the gap between EOPF datasets and the emerging 
 ✅ **Scientific Accuracy** - Preserves native CRS and data integrity  
 ✅ **Cloud-Native** - Optimized for S3 and distributed processing  
 ✅ **Performance** - Intelligent chunking and multiscale pyramids  
-✅ **Standards Compliant** - Full GeoZarr 0.4 and CF conventions support  
+✅ **Standards Aligned** - GeoZarr and CF conventions support  
 ✅ **Production Ready** - Robust error handling and validation  
 
 ## Key Features
@@ -52,7 +52,7 @@ Full support for AWS S3 and S3-compatible storage with automatic credential dete
 
 ### 📋 Standards Compliance
 
-- **GeoZarr 0.4 specification** compliance
+- **GeoZarr conventions** (`multiscales`, `geo-proj`, `spatial`)
 - **CF conventions** for scientific metadata
 - **`_ARRAY_DIMENSIONS`** attributes on all arrays
 - **Grid mapping** variables with proper CRS information

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -21,7 +21,7 @@ eopf-geozarr convert input.zarr output.zarr
 That's it! The converter will:
 
 - Analyze your EOPF dataset structure
-- Apply GeoZarr 0.4 specification compliance
+- Apply the GeoZarr conventions
 - Create multiscale overviews
 - Preserve native CRS and scientific accuracy
 
@@ -186,7 +186,7 @@ client.close()
 
 Your converted dataset now includes:
 
-✅ **GeoZarr 0.4 Compliance** - Full specification adherence  
+✅ **GeoZarr Conventions** - multiscales, geo-proj and spatial  
 ✅ **Native CRS Preservation** - No unnecessary reprojection  
 ✅ **Multiscale Pyramids** - Efficient overview levels  
 ✅ **Optimized Chunking** - Aligned chunks for performance  

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: EOPF GeoZarr Data Model
-site_description: Documentation for the EOPF GeoZarr library - converting EOPF datasets to GeoZarr-spec 0.4 compliant format
+site_description: Documentation for the EOPF GeoZarr library - converting EOPF datasets to GeoZarr format
 site_author: Development Seed
 repo_url: https://github.com/eopf-explorer/data-model
 edit_uri: edit/main/docs/

--- a/src/eopf_geozarr/conversion/geozarr.py
+++ b/src/eopf_geozarr/conversion/geozarr.py
@@ -1,7 +1,7 @@
 """
-GeoZarr-spec 0.4 compliant conversion tools for EOPF datasets.
+GeoZarr compliant conversion tools for EOPF datasets.
 
-This module provides functions to convert EOPF datasets to GeoZarr-spec 0.4 compliant format
+This module provides functions to convert EOPF datasets to GeoZarr format
 while maintaining native projections and using /2 downsampling logic.
 
 Key compliance features:
@@ -69,7 +69,7 @@ def create_geozarr_dataset(
     enable_sharding: bool = False,
 ) -> xr.DataTree:
     """
-    Create a GeoZarr-spec 0.4 compliant dataset from EOPF data.
+    Create a GeoZarr-spec compliant dataset from EOPF data.
 
     Parameters
     ----------
@@ -487,7 +487,7 @@ def write_geozarr_group(
     # Create encoding for all variables
     encoding = _create_geozarr_encoding(ds, compressor, spatial_chunk, enable_sharding)
 
-    # Write native data directly at the group path (GeoZarr 0.4 layout)
+    # Write native data directly at the group path (GeoZarr multiscales layout)
     native_dataset_group_name = group_name
     native_dataset_path = f"{output_path}/{native_dataset_group_name.lstrip('/')}"
 
@@ -555,7 +555,7 @@ def create_geozarr_compliant_multiscales(
     enable_sharding: bool = False,
 ) -> dict[str, Any]:
     """
-    Create GeoZarr-spec 0.4 compliant multiscales for a group.
+    Create GeoZarr-spec compliant multiscales for a group.
 
     Native data is expected to already be written at ``group_name``.
     Overview sub-groups are written at ``{group_name}/r{scale}``


### PR DESCRIPTION
Revise all documentation references from GeoZarr-spec 0.4 to GeoZarr format, aligning with the current conventions and clarifying the library's compliance with the evolving GeoZarr standards.