### PR TITLE
ci: run CI on the cpm-geozarr branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, cpm-geozarr ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, cpm-geozarr ]
   schedule:
     # Weekly run; also triggers the eopf-latest drift check below.
     - cron: '17 6 * * 1'

--- a/src/eopf_geozarr/cpm/writer.py
+++ b/src/eopf_geozarr/cpm/writer.py
@@ -219,7 +219,9 @@ class GeoZarrWriter(EOWriter):
                 )
             generic_groups = list(groups)
         resolved_spatial_chunk = (
-            spatial_chunk if spatial_chunk is not None else _DEFAULT_SPATIAL_CHUNK[selected_pipeline]
+            spatial_chunk
+            if spatial_chunk is not None
+            else _DEFAULT_SPATIAL_CHUNK[selected_pipeline]
         )
         output_path = self._prepare_target(filename_or_obj, mode=mode)
         log.info(


### PR DESCRIPTION
Closes #253.

The workflow only triggered on `main`, so nothing on `cpm-geozarr` ever got checks. #247 — 20 commits, +29105/-3763 across 23 files — has never had a single check run against it.

This matters more than usual: the EOPF Sentinel Zarr Samples Service runs this branch in its September GeoZarr production track, so changes here reach a production pipeline without being checked.

Opening this against `cpm-geozarr` so it takes effect for #247 immediately. Merging it should cause #247 to get its first check run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)