### PR TITLE
fix(s1): correct the emitted STAC items and the data model that rejects them

### DIFF
--- a/src/eopf_geozarr/data_api/__init__.py
+++ b/src/eopf_geozarr/data_api/__init__.py
@@ -4,6 +4,7 @@ The Sentinel-2 models in this package are zarr-integrated, extending pydantic-za
 GroupSpec and ArraySpec classes for direct reading/writing of zarr stores.
 """
 
+from eopf_geozarr.data_api.s1_rtc import S1RtcRoot
 from eopf_geozarr.data_api.s2 import (
     ALL_BAND_NAMES,
     NATIVE_BANDS,
@@ -34,6 +35,7 @@ __all__ = [
     "QualityDataName",
     "ResolutionLevel",
     # Models
+    "S1RtcRoot",
     "Sentinel2BandInfo",
     "Sentinel2ConditionsGroup",
     "Sentinel2CoordinateArray",

--- a/src/eopf_geozarr/data_api/s1_rtc.py
+++ b/src/eopf_geozarr/data_api/s1_rtc.py
@@ -19,19 +19,23 @@ Store hierarchy::
     │   │   ├── vh/            # (time, Y, X) float32
     │   │   ├── border_mask/   # (time, Y, X) uint8
     │   │   ├── time/          # (time,) int64 datetime
+    │   │   ├── x/, y/         # (X,) / (Y,) float64
+    │   │   ├── spatial_ref/   # CF grid mapping (scalar)
     │   │   ├── absolute_orbit/
     │   │   ├── relative_orbit/
     │   │   └── platform/
-    │   ├── r20m/ … r720m/     # overview levels (vv, vh, border_mask only)
+    │   ├── r20m/ … r720m/     # overview levels: vv, vh, border_mask +
+    │   │                      #   time, x, y, spatial_ref (no orbit metadata)
     │   └── conditions/
-    │       └── gamma_area_{orbit}/  # (Y, X) float32
+    │       ├── x/, y/, spatial_ref/
+    │       └── gamma_area_{orbit}/  # (Y, X) float32; also lia_*/incidence_angle_*
     └── descending/
         └── (same structure)
 """
 
 from __future__ import annotations
 
-from typing import Any, Literal, Self
+from typing import TYPE_CHECKING, Any, Literal, Self
 
 from pydantic import BaseModel, Field, model_validator
 from typing_extensions import TypedDict
@@ -42,6 +46,9 @@ from zarr_cm import spatial as spatial_cm
 from eopf_geozarr.data_api.geozarr.common import DatasetAttrs
 from eopf_geozarr.data_api.geozarr.multiscales.zcm import Multiscales
 from eopf_geozarr.pyz.v3 import ArraySpec, GroupSpec
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 # ============================================================================
 # Constants
@@ -141,14 +148,23 @@ class S1RtcConditionsAttrs(BaseModel):
 class S1RtcNativeResolutionMembers(TypedDict, closed=True, total=False):
     """Members for the native resolution dataset (r10m).
 
-    Data variables (time, Y, X) plus 1-D coordinate variables (time,).
-    All fields optional since not all arrays are present during incremental construction.
+    Data variables (time, Y, X), the 1-D coordinates (`time`, `y`, `x`), the per-acquisition
+    metadata arrays (time,) and the CF `spatial_ref` grid-mapping scalar.
+
+    Every key is optional *in the type* so the members mapping can be built up incrementally;
+    presence of the coordinate arrays is enforced separately by `validate_coordinate_arrays`.
+    That split is deliberate — `Required[...]` here would break incremental construction, while
+    relying on the closed TypedDict alone could never detect a writer that *stops* emitting a
+    coordinate, which is exactly the data-model #192 regression class.
     """
 
     vv: ArraySpec[Any]
     vh: ArraySpec[Any]
     border_mask: ArraySpec[Any]
     time: ArraySpec[Any]
+    x: ArraySpec[Any]
+    y: ArraySpec[Any]
+    spatial_ref: ArraySpec[Any]
     absolute_orbit: ArraySpec[Any]
     relative_orbit: ArraySpec[Any]
     platform: ArraySpec[Any]
@@ -157,17 +173,53 @@ class S1RtcNativeResolutionMembers(TypedDict, closed=True, total=False):
 class S1RtcOverviewResolutionMembers(TypedDict, closed=True, total=False):
     """Members for overview resolution datasets (r20m … r720m).
 
-    Only data variables, no coordinate arrays.
+    Data variables plus the same coordinate set as the native level: `x`/`y` (georeferencing),
+    `spatial_ref` (CF grid mapping) and `time`. `time` is replicated at every level with
+    identical values — TiTiler renders previews off a coarse level, and a level without `time`
+    cannot be selected by datetime (data-model #192) — so an overview is *not* a data-only group.
+
+    None of the per-acquisition metadata arrays (`absolute_orbit`, `relative_orbit`, `platform`)
+    are written at overview levels; they live on r10m only.
     """
 
     vv: ArraySpec[Any]
     vh: ArraySpec[Any]
     border_mask: ArraySpec[Any]
+    time: ArraySpec[Any]
+    x: ArraySpec[Any]
+    y: ArraySpec[Any]
+    spatial_ref: ArraySpec[Any]
 
 
 # ============================================================================
 # Group models (same pattern as S2 Sentinel2ResolutionDataset etc.)
 # ============================================================================
+
+# Coordinate arrays every resolution level must carry, native and overview alike. Listing them
+# in the member TypedDicts only stops them being rejected as `extra_forbidden`; because both
+# TypedDicts are `total=False` (needed for the incremental `.get()` construction pattern), every
+# key is NotRequired, so nothing in the type would notice a writer that STOPPED emitting one.
+# That is exactly the regression class this model exists to catch: `time` was missing from the
+# overview levels until data-model #192, which made datetime `.sel` fail on the coarse levels
+# TiTiler renders previews from. `x`/`y` absent means the level has no georeferencing at all
+# (rioxarray falls back to an identity transform), and `spatial_ref` absent means its CRS cannot
+# be resolved. Hence the explicit presence check below rather than `Required[...]`.
+LEVEL_COORDINATE_ARRAYS = ("time", "x", "y", "spatial_ref")
+
+# The conditions group holds time-invariant rasters, so it carries no `time` — but it does need
+# the spatial coordinates. Without them the group opens with "dimensions without coordinates" and
+# rioxarray infers an identity transform: the georeferencing is absent, not merely undeclared.
+CONDITION_COORDINATE_ARRAYS = ("x", "y", "spatial_ref")
+
+
+def _validate_coordinates(members: Mapping[str, Any], kind: str, required: tuple[str, ...]) -> None:
+    """Raise unless every coordinate in ``required`` is present in ``members``."""
+    missing = [name for name in required if name not in members]
+    if missing:
+        raise ValueError(
+            f"{kind} must contain coordinate arrays {missing} "
+            f"(expected {list(required)}; see data-model #192)"
+        )
 
 
 class S1RtcNativeResolutionDataset(GroupSpec[S1RtcResolutionAttrs, S1RtcNativeResolutionMembers]):
@@ -179,6 +231,12 @@ class S1RtcNativeResolutionDataset(GroupSpec[S1RtcResolutionAttrs, S1RtcNativeRe
         for name in ("vv", "vh", "border_mask"):
             if name not in self.members:
                 raise ValueError(f"Native resolution dataset must contain '{name}' array")
+        return self
+
+    @model_validator(mode="after")
+    def validate_coordinate_arrays(self) -> Self:
+        """Ensure time, x, y and spatial_ref are present (see LEVEL_COORDINATE_ARRAYS)."""
+        _validate_coordinates(self.members, "Native resolution dataset", LEVEL_COORDINATE_ARRAYS)
         return self
 
     @property
@@ -208,17 +266,50 @@ class S1RtcNativeResolutionDataset(GroupSpec[S1RtcResolutionAttrs, S1RtcNativeRe
 class S1RtcOverviewResolutionDataset(
     GroupSpec[S1RtcResolutionAttrs, S1RtcOverviewResolutionMembers]
 ):
-    """An overview resolution dataset (r20m-r720m): data variables only."""
+    """An overview resolution dataset (r20m-r720m): data variables + coordinate arrays."""
+
+    @model_validator(mode="after")
+    def validate_coordinate_arrays(self) -> Self:
+        """Ensure time, x, y and spatial_ref are present (see LEVEL_COORDINATE_ARRAYS)."""
+        _validate_coordinates(self.members, "Overview resolution dataset", LEVEL_COORDINATE_ARRAYS)
+        return self
+
+
+# Arrays the writer can put in a conditions group. `ingest_s1tiling_conditions` takes three
+# optional GeoTIFF paths and only requires that *one* of them be given, so a store whose
+# conditions group holds nothing but `lia_*` (or `incidence_angle_*`) is writable today — and
+# the CLI's three condition flags all default to None, so it is reachable without any special
+# invocation. Requiring `gamma_area_*` specifically made those stores unopenable by this model.
+CONDITION_ARRAY_PREFIXES = ("gamma_area_", "lia_", "incidence_angle_")
 
 
 class S1RtcConditionsGroup(GroupSpec[S1RtcConditionsAttrs, dict[str, ArraySpec[Any]]]):
     """Time-invariant condition arrays, keyed by name (e.g. gamma_area_008)."""
 
+    # ORDER MATTERS: this runs before `validate_has_condition_array`, so a group missing both its
+    # coordinates and its rasters reports the coordinates. Swapping the two changes which error an
+    # operator sees; `test_s1_rtc_rejects_conditions_without_condition_arrays` keeps its
+    # coordinates precisely so it exercises the other check.
     @model_validator(mode="after")
-    def validate_has_gamma_area(self) -> Self:
-        """At least one gamma_area_* array should be present."""
-        if not any(k.startswith("gamma_area_") for k in self.members):
-            raise ValueError("Conditions group must contain at least one 'gamma_area_*' array")
+    def validate_coordinate_arrays(self) -> Self:
+        """Ensure x, y and spatial_ref are present (see CONDITION_COORDINATE_ARRAYS).
+
+        Same reasoning as the resolution levels: without 1-D coordinates the group opens with
+        "dimensions without coordinates" and its rasters are not georeferenced at all. The writer
+        creates them with the group, so this closes the last member-level hole rather than
+        guarding a path it can currently reach.
+        """
+        _validate_coordinates(self.members, "Conditions group", CONDITION_COORDINATE_ARRAYS)
+        return self
+
+    @model_validator(mode="after")
+    def validate_has_condition_array(self) -> Self:
+        """At least one condition array must be present (see CONDITION_ARRAY_PREFIXES)."""
+        if not any(k.startswith(CONDITION_ARRAY_PREFIXES) for k in self.members):
+            raise ValueError(
+                "Conditions group must contain at least one condition array "
+                f"(one of {CONDITION_ARRAY_PREFIXES})"
+            )
         return self
 
 
@@ -291,10 +382,11 @@ class S1RtcRoot(GroupSpec[DatasetAttrs, S1RtcRootMembers]):
         │   │   ├── vh/            # (time, Y, X) float32
         │   │   ├── border_mask/   # (time, Y, X) uint8
         │   │   ├── time/          # (time,) int64
+        │   │   ├── x/, y/, spatial_ref/
         │   │   ├── absolute_orbit/
         │   │   ├── relative_orbit/
         │   │   └── platform/
-        │   ├── r20m/ … r720m/
+        │   ├── r20m/ … r720m/     # + time, x, y, spatial_ref at every level
         │   └── conditions/
         │       └── gamma_area_{orbit}/
         └── descending/

--- a/src/eopf_geozarr/stac/s1_rtc.py
+++ b/src/eopf_geozarr/stac/s1_rtc.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import re
 from pathlib import Path
 from typing import NamedTuple, cast
 
@@ -19,10 +20,23 @@ SAT_EXT = "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
 PROJ_EXT = "https://stac-extensions.github.io/projection/v2.0.0/schema.json"
 RENDER_EXT = "https://stac-extensions.github.io/render/v1.0.0/schema.json"
 DATACUBE_EXT = "https://stac-extensions.github.io/datacube/v2.2.0/schema.json"
-TIMESTAMPS_EXT = "https://stac-extensions.github.io/timestamps/v1.1.0/schema.json"
 GRID_EXT = "https://stac-extensions.github.io/grid/v1.1.0/schema.json"
+# No TIMESTAMPS_EXT: `created`/`updated` are STAC *Common Metadata*, present in the core Item spec.
+# The timestamps extension only adds `published`/`expires`/`unpublished`, none of which this builder
+# emits, so declaring it was inert — a validator downloaded a schema that constrained nothing.
 
 ZARR_MEDIA_TYPE = "application/vnd.zarr; version=3"
+
+# MGRS tile id as written by S1Tiling / the Sentinel-2 grid: two-digit UTM zone (01-60), latitude
+# band, then the 100 km square column/row letters. `I` and `O` are excluded throughout (they read as
+# 1/0), and row letters stop at V. Anchored, because the id becomes both the STAC item id and the
+# queryable `grid:code` — see `_tile_id_from_store`.
+_MGRS_TILE_RE = re.compile(r"^(0[1-9]|[1-5][0-9]|60)[C-HJ-NP-X][A-HJ-NP-Z][A-HJ-NP-V]$")
+
+# Store-name prefixes the tile id may hide behind. "s1-rtc-" is the current one; "s1-grd-rtc-" is
+# what #246 reverts to once titiler-eopf#108 lands. Accepting both means that rename does not turn
+# every store into a hard build failure the day it happens (see `_tile_id_from_store`).
+_STORE_PREFIXES = ("s1-rtc-", "s1-grd-rtc-")
 
 _ORBIT_PREFERENCE = ("ascending", "descending")
 # Short suffix for orbit-keyed asset names (gamma0-rtc-backscatter-asc / -desc).
@@ -51,14 +65,87 @@ def _rgb_render(orbit: str) -> dict[str, object]:
     vv = f"/{orbit}:vv"
     vh = f"/{orbit}:vh"
     return {
+        # `assets` is the ONE required field of a Render Object (render v1.0.0,
+        # `definitions/fields.required`). Omitting it made every emitted item fail the extension it
+        # declared — `'assets' is a required property` — so `generate-stac-s1 | stac-validator`
+        # failed and a validating STAC API refused the item. It names the orbit-keyed γ⁰ asset this
+        # composite reads from, which is exactly the asset built below.
+        "assets": [f"gamma0-rtc-backscatter-{_ORBIT_SHORT[orbit]}"],
         "title": "VV, VH, VV/VH composite",
         "expression": f"{vv};{vh};({vv})/({vh})",
         # Per-band linear stretch: VV/VH are low-valued gamma0; the VV/VH ratio spans ~1-15.
         # One shared pair saturated the ratio band (purple wash) and dropped low-cross-pol water.
         "rescale": [[0.0, 0.4], [0.0, 0.1], [1.0, 15.0]],
         "bidx": [1],
+        # Not a render-extension field, but the schema sets `additionalProperties: true` on the
+        # Render Object, so it validates. titiler reads it to size the tiles it renders from this
+        # config; dropping it would silently fall back to titiler's default tile size.
         "tilesize": 256,
     }
+
+
+def _providers() -> list[dict[str, object]]:
+    """Attribution for the γ⁰ RTC product, copied down from the collection block.
+
+    A STAC API search returns bare items, without the collection that would otherwise supply this,
+    so an item that omits `providers` loses its attribution entirely for every consumer that does
+    not follow the collection link. Kept in sync by hand with the collection templates
+    (`stac/sentinel-1-grd-rtc*.json` in data-pipeline), which stay the source of truth — the
+    collection is registered by the operator, not by this builder.
+
+    Returned fresh per call: the dicts land in `item.properties` and must not be shared between
+    items (mutating one item's providers would rewrite every other item's).
+    """
+    return [
+        {
+            "name": "European Commission",
+            "roles": ["licensor"],
+            "url": "https://commission.europa.eu/",
+        },
+        {
+            "name": "ESA",
+            "roles": ["producer", "processor"],
+            "url": "https://sentinel.esa.int/web/sentinel/missions/sentinel-1",
+        },
+        {
+            "name": "EOPF Sentinel Zarr Samples Service",
+            "roles": ["host", "processor"],
+            "url": "https://zarr.eopf.copernicus.eu/",
+        },
+    ]
+
+
+def _tile_id_from_store(zarr_store: str) -> str:
+    """Derive (and validate) the MGRS tile id from the store name.
+
+    The store is written as ``s1-rtc-{tile}.zarr`` so its basename equals the item id, which
+    titiler-eopf reconstructs as the render path (it ignores the asset href) — see the TEMPORARY
+    note on #246 in :func:`build_s1_rtc_stac_item`.
+
+    Stripping the prefix/suffix and *trusting* the remainder silently minted malformed ids from any
+    other store name: ``cube.zarr`` produced item id ``s1-rtc-cube`` and ``grid:code`` ``MGRS-cube``,
+    ``s1-rtc-.zarr`` produced ``s1-rtc-`` / ``MGRS-``, and (before ``s1-grd-rtc-`` was accepted here)
+    ``s1-grd-rtc-31TCH.zarr`` produced ``s1-rtc-s1-grd-rtc-31TCH`` / ``MGRS-s1-grd-rtc-31TCH``. None
+    of these fail anywhere downstream: they register cleanly and poison the catalogue, because
+    ``grid:code`` is the field tile-filtered searches and the cube↔acquisition cross-links join on.
+    Validate instead, and fail the build where the mistake is still cheap to fix.
+
+    Raises
+    ------
+    ValueError
+        If the store name does not carry a well-formed MGRS tile id.
+    """
+    name = Path(zarr_store).name
+    tile_id = name.removesuffix(".zarr")
+    for prefix in _STORE_PREFIXES:
+        tile_id = tile_id.removeprefix(prefix)
+    if not _MGRS_TILE_RE.match(tile_id):
+        raise ValueError(
+            f"Cannot derive an MGRS tile id from store name {name!r} (got {tile_id!r}). "
+            f"Expected a store named {{{'|'.join(_STORE_PREFIXES)}}}<MGRS tile>.zarr, "
+            "e.g. s1-rtc-31TCH.zarr."
+        )
+    return tile_id
 
 
 def _gamma0_bands() -> list[dict[str, object]]:
@@ -76,24 +163,83 @@ def _gamma0_bands() -> list[dict[str, object]]:
 
 
 def _utm_to_wgs84(proj_code: CRSCode, utm_bbox: BoundingBox2D) -> BoundingBox2D:
-    """Convert UTM (xmin, ymin, xmax, ymax) to WGS84 (west, south, east, north)."""
-    xmin, ymin, xmax, ymax = utm_bbox
+    """Convert UTM (xmin, ymin, xmax, ymax) to WGS84 (west, south, east, north).
+
+    Transforming only the four corners is wrong twice over. It understates the footprint everywhere
+    (projected edges curve in lon/lat, so the extreme lat/lon is mid-edge, not at a corner), and in
+    UTM zones 1 and 60 it produces a near-global box: tile 01VCK at 300000-409800E in EPSG:32601
+    corner-transforms to ``(-178.41, 54.11, 179.94, 55.13)`` — 358.4 degrees wide, spanning almost
+    the whole planet — because the west edge lands just *east* of the antimeridian and the east edge
+    just *west* of it, and min/max then straddle the wrap instead of the tile.
+
+    ``Transformer.transform_bounds(..., densify_pts=21)`` fixes both: it samples along the edges and
+    returns the antimeridian-crossing box ``(179.87, 54.11, -178.38, 55.13)``, where ``west > east``
+    — the representation STAC and GeoJSON (RFC 7946 §5.2) prescribe for a crossing bbox.
+    Callers must therefore not assume ``west <= east``; see ``_union_wgs84`` and
+    ``_bbox_to_geometry``, which both handle the crossing case.
+
+    Duplicated (deliberately, in the densification only) from
+    :func:`eopf_geozarr.conversion.utils.write_store_root_geo_metadata`, which reprojects the
+    store-root footprint the same way. Not extracted into a shared helper: the shared part is the
+    one ``transform_bounds`` call, and the two call sites want *opposite* crossing behaviour — the
+    store-root writer widens a crossing union to the full longitude range, while a STAC item must
+    keep the narrow crossing box so spatial search stays selective.
+    """
     transformer = pyproj.Transformer.from_crs(proj_code, "EPSG:4326", always_xy=True)
-    xs = [xmin, xmax, xmin, xmax]
-    ys = [ymin, ymin, ymax, ymax]
-    lons, lats = transformer.transform(xs, ys)
-    return BoundingBox2D((min(lons), min(lats), max(lons), max(lats)))
+    return BoundingBox2D(transformer.transform_bounds(*utm_bbox, densify_pts=21))
+
+
+def _union_wgs84(bboxes: list[BoundingBox2D]) -> BoundingBox2D:
+    """Union WGS84 bboxes, keeping an antimeridian crossing narrow rather than wrapping the globe.
+
+    A plain ``min(west)/max(east)`` is only correct while no input crosses the antimeridian; on a
+    crossing box (``west > east``, see :func:`_utm_to_wgs84`) it inverts the box straight back into
+    the 358-degree monster the densification just removed. Instead every box is unwrapped into one
+    continuous frame anchored on the first box's west edge — a crossing box gets ``east += 360``,
+    and a box a whole turn away from the anchor is shifted by 360 so the two are comparable — then
+    the union is folded back into [-180, 180], keeping ``west > east`` if it still crosses.
+    """
+    anchor = bboxes[0][0]
+    spans: list[tuple[float, float]] = []
+    for west_i, _south, east_i, _north in bboxes:
+        if east_i < west_i:
+            east_i += 360.0
+        offset = 360.0 * round((anchor - west_i) / 360.0)
+        spans.append((west_i + offset, east_i + offset))
+
+    west = min(s[0] for s in spans)
+    east = max(s[1] for s in spans)
+    if east > 180.0:
+        east -= 360.0
+    if west > 180.0:
+        west -= 360.0
+    elif west < -180.0:
+        west += 360.0
+    return BoundingBox2D((west, min(b[1] for b in bboxes), east, max(b[3] for b in bboxes)))
 
 
 def _bbox_to_geometry(bbox: BoundingBox2D) -> dict[str, object]:
-    """A closed rectangular Polygon for a WGS84 [west, south, east, north] bbox."""
+    """A closed rectangular Polygon for a WGS84 [west, south, east, north] bbox.
+
+    A bbox that crosses the antimeridian (``west > east``) becomes a two-part MultiPolygon split at
+    ±180: a single ring from ``west`` to ``east`` would run the *long* way round the globe, drawing
+    a footprint covering everything except the tile. GeoJSON (RFC 7946 §3.1.9) requires the split.
+    """
     west, south, east, north = bbox
-    return {
-        "type": "Polygon",
-        "coordinates": [
-            [[west, south], [east, south], [east, north], [west, north], [west, south]]
-        ],
-    }
+    if west > east:
+        # Drop a part with no width. An edge landing exactly on ±180 makes one half of the split
+        # degenerate, and a zero-area ring is rejected by geometry stacks that check validity
+        # (PostGIS ST_IsValid, shapely-based ingest) even though RFC 7946 does not forbid it.
+        parts = [[_ring(w, south, e, north)] for w, e in ((west, 180.0), (-180.0, east)) if w != e]
+        if len(parts) == 1:
+            return {"type": "Polygon", "coordinates": parts[0]}
+        return {"type": "MultiPolygon", "coordinates": parts}
+    return {"type": "Polygon", "coordinates": [_ring(west, south, east, north)]}
+
+
+def _ring(west: float, south: float, east: float, north: float) -> list[list[float]]:
+    """A closed counter-clockwise rectangular ring."""
+    return [[west, south], [east, south], [east, north], [west, north], [west, south]]
 
 
 def _open_root(zarr_store: str) -> zarr.Group:
@@ -117,6 +263,48 @@ def _open_root(zarr_store: str) -> zarr.Group:
         use_consolidated=None,
         storage_options=cast("dict[str, object] | None", fs_utils.get_storage_options(zarr_store)),
     )
+
+
+def _orbit_numbers(r10m: zarr.Group, name: str) -> list[int | None]:
+    """Per-acquisition ``absolute_orbit`` / ``relative_orbit`` values from an r10m group.
+
+    ``s1_ingest.py`` writes both as int32 coordinates on the ``time`` axis at native resolution
+    only. Read best-effort — the same posture the r10m ``spatial:*`` attrs get above — so minimal
+    and pre-#216 stores that predate these coordinates still build an item, just without the
+    ``sat:*_orbit`` fields.
+    """
+    if name not in r10m:
+        return []
+    # `0` means "not recorded", never orbit zero. Both arrays are created with `fill_value=0`, and
+    # the append resizes all three metadata coordinates before writing them, so a torn append
+    # leaves a correctly-shaped slice holding 0 — and there is a known upstream bug putting 0 on
+    # some live slices. The sat extension declares both fields `{"type": "integer", "minimum": 1}`,
+    # so emitting a 0 makes a validating STAC API reject the item outright. Map it to None here
+    # rather than dropping it, so the per-slice zip below stays aligned with `time`.
+    return [
+        int(v) if int(v) > 0 else None for v in np.asarray(cast("zarr.Array", r10m[name])).tolist()
+    ]
+
+
+def _single(values: list[int | None], expected: int) -> int | None:
+    """The one distinct value in *values*, or ``None`` unless all *expected* slices agree.
+
+    ``sat:relative_orbit`` / ``sat:absolute_orbit`` are single-valued STAC fields, so a cube can only
+    carry them when its acquisitions agree. In practice a single-orbit tile cube shares one relative
+    orbit (one track) and so gets the field, while absolute orbit is unique per acquisition and so is
+    dropped from any multi-acquisition cube — the per-acquisition items are where it is exact.
+
+    ``expected`` is the cube's total slice count, and requiring it guards a subtler case than
+    disagreement: values are pooled only from orbit groups that actually carry the coordinate, so a
+    dual-orbit cube with one group written before these coordinates existed would otherwise pool
+    just the other group's values and confidently assert one track for acquisitions from *both*
+    orbit directions. A `None` anywhere (an unrecorded slice) likewise means the cube cannot claim
+    a single value.
+    """
+    if len(values) != expected or any(v is None for v in values):
+        return None
+    distinct = set(values)
+    return distinct.pop() if len(distinct) == 1 else None
 
 
 class _OrbitInfo(NamedTuple):
@@ -146,16 +334,20 @@ def build_s1_rtc_stac_item(zarr_store: str, collection_id: str) -> pystac.Item:
     Raises
     ------
     ValueError
-        If the store contains no acquisitions.
+        If the store contains no acquisitions, or its name carries no valid MGRS tile id.
     """
     # TEMPORARY (#246): the store is written as s1-rtc-{tile}.zarr so its filename equals
     # the item id, which titiler-eopf reconstructs as the render path (it ignores the asset
-    # href). Revert this prefix to "s1-grd-rtc-" when titiler-eopf#108 lands.
-    tile_id = Path(zarr_store).name.removeprefix("s1-rtc-").removesuffix(".zarr")
+    # href). `_STORE_PREFIXES` accepts both this name and the "s1-grd-rtc-" one it reverts to
+    # once titiler-eopf#108 lands; drop the stale entry then.
+    tile_id = _tile_id_from_store(zarr_store)
 
     root = _open_root(zarr_store)
 
     all_times_ns: list[int] = []
+    # Per-acquisition orbit numbers, pooled across orbit groups; see the single-value guard below.
+    all_absolute_orbits: list[int | None] = []
+    all_relative_orbits: list[int | None] = []
     wgs84_bboxes: list[BoundingBox2D] = []
     # Per present orbit, in preference order: the metadata needed for assets, projection and datacube.
     present: list[_OrbitInfo] = []
@@ -177,6 +369,8 @@ def build_s1_rtc_stac_item(zarr_store: str, collection_id: str) -> pystac.Item:
         # minimal/legacy stores without them still build (just without those projection refinements).
         r10m_attrs = dict(r10m.attrs)
         all_times_ns.extend(times)
+        all_absolute_orbits.extend(_orbit_numbers(r10m, "absolute_orbit"))
+        all_relative_orbits.extend(_orbit_numbers(r10m, "relative_orbit"))
         wgs84_bboxes.append(_utm_to_wgs84(proj_code, utm_bbox))
         present.append(
             _OrbitInfo(
@@ -195,12 +389,8 @@ def build_s1_rtc_stac_item(zarr_store: str, collection_id: str) -> pystac.Item:
     start_dt = dt.datetime.fromtimestamp(min(all_times_ns) / 1e9, tz=dt.UTC)
     end_dt = dt.datetime.fromtimestamp(max(all_times_ns) / 1e9, tz=dt.UTC)
 
-    # WGS84 bbox union across all present orbit directions
-    west = min(b[0] for b in wgs84_bboxes)
-    south = min(b[1] for b in wgs84_bboxes)
-    east = max(b[2] for b in wgs84_bboxes)
-    north = max(b[3] for b in wgs84_bboxes)
-    wgs84_bbox = BoundingBox2D((west, south, east, north))
+    # WGS84 bbox union across all present orbit directions (antimeridian-aware — see _union_wgs84)
+    wgs84_bbox = _union_wgs84(wgs84_bboxes)
 
     geometry = _bbox_to_geometry(wgs84_bbox)
 
@@ -211,6 +401,7 @@ def build_s1_rtc_stac_item(zarr_store: str, collection_id: str) -> pystac.Item:
     preferred_proj_code = preferred.proj_code
     preferred_bbox = preferred.utm_bbox
 
+    build_time = dt.datetime.now(tz=dt.UTC).isoformat()
     properties: dict[str, object] = {
         "start_datetime": start_dt.isoformat(),
         "end_datetime": end_dt.isoformat(),
@@ -219,10 +410,16 @@ def build_s1_rtc_stac_item(zarr_store: str, collection_id: str) -> pystac.Item:
             "Radiometric-terrain-corrected (RTC) γ⁰ backscatter datacube from Sentinel-1 GRD, "
             "reprojected onto the Sentinel-2 MGRS/UTM grid."
         ),
-        # `updated` (timestamps extension) tracks this metadata build. `created` is intentionally
-        # omitted: it means the item's creation instant, which the store does not record — using an
-        # acquisition time would misuse the field, and a build-time value would churn on every append.
-        "updated": dt.datetime.now(tz=dt.UTC).isoformat(),
+        # STAC Common Metadata (NOT the timestamps extension — that only adds published/expires/
+        # unpublished, which this builder never sets). Both mark this metadata build: `created` is
+        # required by the S1 RTC collection, and the store records no separate item-creation instant,
+        # so build time is the only honest value available. It does churn when a cube is rebuilt
+        # after an append; that is the accepted cost of emitting the field at all.
+        "created": build_time,
+        "updated": build_time,
+        # Attribution, copied down from the collection block: a STAC API search returns items
+        # without their collection, so an item that omits `providers` has no attribution at all.
+        "providers": _providers(),
         # Identity invariants (constant across the cube; platform is per-acquisition so omitted here —
         # a cube can mix S1A and S1C).
         "constellation": "sentinel-1",
@@ -240,21 +437,30 @@ def build_s1_rtc_stac_item(zarr_store: str, collection_id: str) -> pystac.Item:
         # Grid extension: the Sentinel-2 MGRS tile this cube is gridded onto — a queryable tile id
         # (enables tile-filtering the acquisitions collection and cube↔acquisition cross-links).
         "grid:code": f"MGRS-{tile_id}",
-        # Render extension: dual-pol RGB composite for previews/tiles (defaults to the preferred orbit)
-        "renders": {"rgb": _rgb_render(preferred_orbit)},
     }
     if preferred.shape is not None:
         properties["proj:shape"] = preferred.shape
     if preferred.transform is not None:
         properties["proj:transform"] = preferred.transform
 
-    stac_extensions = [SAR_EXT, PROJ_EXT, RENDER_EXT, DATACUBE_EXT, TIMESTAMPS_EXT, GRID_EXT]
+    stac_extensions = [SAR_EXT, PROJ_EXT, RENDER_EXT, DATACUBE_EXT, GRID_EXT]
 
-    # sat:orbit_state is single-valued, so it's only meaningful when the cube holds a single orbit. A
-    # dual-orbit cube would mislabel half its slices — omit it there (per-acquisition items, which are
-    # single-orbit, carry the real value). Only declare the SAT extension when the field is set.
+    # Every sat:* field is single-valued, so each is set only where the cube actually agrees on it,
+    # and the SAT extension is declared only if at least one landed.
+    #   - sat:orbit_state: a dual-orbit cube would mislabel half its slices, so omit it there.
+    #   - sat:relative_orbit: constant while the tile is covered by one track (the usual case).
+    #   - sat:absolute_orbit: unique per acquisition, so a multi-acquisition cube drops it.
+    # The per-acquisition items are single-orbit and single-slice, so they carry all three exactly.
     if len(present) == 1:
         properties["sat:orbit_state"] = preferred_orbit
+    for field, values in (
+        ("sat:relative_orbit", all_relative_orbits),
+        ("sat:absolute_orbit", all_absolute_orbits),
+    ):
+        single = _single(values, len(all_times_ns))
+        if single is not None:
+            properties[field] = single
+    if any(k.startswith("sat:") for k in properties):
         stac_extensions.append(SAT_EXT)
 
     # Datacube extension. The time axis is irregularly sampled, so it lists its discrete `values` (the
@@ -262,7 +468,14 @@ def build_s1_rtc_stac_item(zarr_store: str, collection_id: str) -> pystac.Item:
     # and the list stays modest (bounded by the tile's acquisitions). The regular x/y axes instead carry
     # extent + step (their element count is derivable, and the exact pixel count is in proj:shape);
     # enumerating their ~10⁴ coordinates would not scale.
-    epsg = pyproj.CRS.from_user_input(preferred_proj_code).to_epsg()
+    # `to_epsg()` returns None for any CRS with no EPSG match — a WKT2/PROJJSON `proj:code`, or a
+    # custom projection — and that None flowed straight into `reference_system`, emitting a literal
+    # `null` that tells a reader nothing about the grid. datacube v2.2.0 accepts an EPSG integer, a
+    # WKT2 string or a PROJJSON object there, so fall back to WKT2 rather than to null.
+    preferred_crs = pyproj.CRS.from_user_input(preferred_proj_code)
+    epsg_or_wkt: object = preferred_crs.to_epsg()
+    if epsg_or_wkt is None:
+        epsg_or_wkt = preferred_crs.to_wkt()
     xmin, ymin, xmax, ymax = preferred_bbox
     time_values = [
         dt.datetime.fromtimestamp(t / 1e9, tz=dt.UTC).isoformat() for t in sorted(set(all_times_ns))
@@ -285,13 +498,13 @@ def build_s1_rtc_stac_item(zarr_store: str, collection_id: str) -> pystac.Item:
         "type": "spatial",
         "axis": "x",
         "extent": [xmin, xmax],
-        "reference_system": epsg,
+        "reference_system": epsg_or_wkt,
     }
     y_dim: dict[str, object] = {
         "type": "spatial",
         "axis": "y",
         "extent": [ymin, ymax],
-        "reference_system": epsg,
+        "reference_system": epsg_or_wkt,
     }
     if preferred.transform is not None:
         transform = cast("list[float]", preferred.transform)
@@ -313,6 +526,13 @@ def build_s1_rtc_stac_item(zarr_store: str, collection_id: str) -> pystac.Item:
         properties=properties,
         stac_extensions=stac_extensions,
         collection=collection_id,
+        # `renders` belongs at the ITEM ROOT, not in `properties`. The render v1.0.0 Item branch
+        # is `required: ["type", "assets", "renders"]` against the item object itself, and the
+        # extension's own examples/item-landsat8.json puts it at the root — only its README's
+        # "Item Properties" table says otherwise, and that contradicts both. Emitting it under
+        # `properties` made every item fail the extension it declared, with the misleading
+        # message "'renders' is a required property".
+        extra_fields={"renders": {"rgb": _rgb_render(preferred_orbit)}},
     )
 
     store_str = str(zarr_store)
@@ -468,12 +688,13 @@ def build_s1_rtc_per_acquisition_items(
     Raises
     ------
     ValueError
-        If the store has no acquisitions, or ``orbit`` is not present in the store.
+        If the store has no acquisitions, ``orbit`` is not present in the store, or the store name
+        carries no valid MGRS tile id.
     """
     if orbit not in _ORBIT_PREFERENCE:
         raise ValueError(f"orbit must be one of {_ORBIT_PREFERENCE}, got {orbit!r}")
 
-    tile_id = Path(zarr_store).name.removeprefix("s1-rtc-").removesuffix(".zarr")
+    tile_id = _tile_id_from_store(zarr_store)
 
     root = _open_root(zarr_store)
     if orbit not in root:
@@ -483,6 +704,27 @@ def build_s1_rtc_per_acquisition_items(
     platforms = np.array(cast("zarr.Array", r10m["platform"])).tolist()
     if not times_ns:
         raise ValueError(f"No acquisitions found for orbit {orbit!r} in: {zarr_store}")
+
+    # Per-slice orbit numbers. Unlike the cube item, a per-acquisition item is single-valued by
+    # construction, so it always carries both when the store records them. `None` per slice when the
+    # coordinates are absent (pre-#216 stores) — see `_orbit_numbers`.
+    absolute_orbits = _orbit_numbers(r10m, "absolute_orbit") or [None] * len(times_ns)
+    relative_orbits = _orbit_numbers(r10m, "relative_orbit") or [None] * len(times_ns)
+
+    # A half-completed resize can leave a metadata coordinate shorter than `time`. Say so, rather
+    # than letting the `zip(..., strict=True)` below fail with "zip() argument 4 is shorter than
+    # arguments 1-3", which names neither the store nor the array.
+    for name, values in (
+        ("platform", platforms),
+        ("absolute_orbit", absolute_orbits),
+        ("relative_orbit", relative_orbits),
+    ):
+        if len(values) != len(times_ns):
+            raise ValueError(
+                f"Cannot build per-acquisition items for {orbit!r} in {zarr_store}: "
+                f"r10m/{name} has {len(values)} entries but r10m/time has {len(times_ns)}. "
+                "The cube is half-built -- re-run the interrupted append or wipe + reingest."
+            )
 
     base = build_s1_rtc_stac_item(zarr_store, collection_id)
     base_dict = base.to_dict(include_self_link=False)
@@ -506,7 +748,9 @@ def build_s1_rtc_per_acquisition_items(
     orbit_geometry = _bbox_to_geometry(orbit_wgs84_bbox)
 
     items: list[pystac.Item] = []
-    for t_ns, platform in zip(times_ns, platforms, strict=True):
+    for t_ns, platform, abs_orbit, rel_orbit in zip(
+        times_ns, platforms, absolute_orbits, relative_orbits, strict=True
+    ):
         when = dt.datetime.fromtimestamp(t_ns / 1e9, tz=dt.UTC)
         item_dict = {**base_dict}
         item_dict["id"] = acquisition_id(tile_id, when)
@@ -521,6 +765,20 @@ def build_s1_rtc_per_acquisition_items(
         props["datetime"] = when.isoformat()
         props["sat:orbit_state"] = orbit
         props["proj:bbox"] = list(orbit_utm_bbox)
+        # Own attribution objects per item: the base's list would otherwise be shared by reference
+        # across every item built from this cube (see `_providers`).
+        props["providers"] = _providers()
+        # Override, never inherit: the cube's single-valued sat:*_orbit (if any) describes the whole
+        # cube. Pop when this orbit group records no orbit numbers, so a value the *other* orbit
+        # contributed to the base cannot leak onto these items.
+        for field, value in (
+            ("sat:absolute_orbit", abs_orbit),
+            ("sat:relative_orbit", rel_orbit),
+        ):
+            if value is None:
+                props.pop(field, None)
+            else:
+                props[field] = value
         # Per-acquisition title carries the datetime + orbit so sibling scenes are distinguishable
         # (the inherited cube title "… — tile {id}" is identical across all acquisitions).
         props["title"] = (
@@ -534,8 +792,11 @@ def build_s1_rtc_per_acquisition_items(
         normalized = _normalize_platform(platform)
         if normalized:
             props["platform"] = normalized
-        props["renders"] = {"rgb": _rgb_render(orbit)}
         item_dict["properties"] = props
+        # At the item ROOT, not in properties — see the note on the cube item's `extra_fields`.
+        # The base item is cloned per acquisition, so this also overrides whatever orbit the cube
+        # chose as preferred.
+        item_dict["renders"] = {"rgb": _rgb_render(orbit)}
 
         # Drop the datacube ext (a single acquisition is not a cube). Ensure the SAT ext is declared:
         # a per-acq item always sets sat:orbit_state, but a dual-orbit cube base omits both.

--- a/src/eopf_geozarr/stac/s1_rtc.py
+++ b/src/eopf_geozarr/stac/s1_rtc.py
@@ -402,6 +402,9 @@ def build_s1_rtc_stac_item(zarr_store: str, collection_id: str) -> pystac.Item:
     preferred_bbox = preferred.utm_bbox
 
     build_time = dt.datetime.now(tz=dt.UTC).isoformat()
+    # Built once and shared by the item root and the `properties` mirror below, so the two cannot
+    # drift apart. Nothing mutates a render config after construction.
+    cube_render = {"rgb": _rgb_render(preferred_orbit)}
     properties: dict[str, object] = {
         "start_datetime": start_dt.isoformat(),
         "end_datetime": end_dt.isoformat(),
@@ -437,6 +440,12 @@ def build_s1_rtc_stac_item(zarr_store: str, collection_id: str) -> pystac.Item:
         # Grid extension: the Sentinel-2 MGRS tile this cube is gridded onto — a queryable tile id
         # (enables tile-filtering the acquisitions collection and cube↔acquisition cross-links).
         "grid:code": f"MGRS-{tile_id}",
+        # COMPATIBILITY MIRROR (remove once data-pipeline is updated -- see the note on
+        # `extra_fields` below). The authoritative copy is the one at the item root; this
+        # duplicate exists only so pinned consumers that read `properties.renders` keep working
+        # across the relocation. Both are built from the same `_rgb_render(preferred_orbit)`
+        # call, so they cannot disagree.
+        "renders": cube_render,
     }
     if preferred.shape is not None:
         properties["proj:shape"] = preferred.shape
@@ -532,7 +541,15 @@ def build_s1_rtc_stac_item(zarr_store: str, collection_id: str) -> pystac.Item:
         # "Item Properties" table says otherwise, and that contradicts both. Emitting it under
         # `properties` made every item fail the extension it declared, with the misleading
         # message "'renders' is a required property".
-        extra_fields={"renders": {"rgb": _rgb_render(preferred_orbit)}},
+        #
+        # It is ALSO mirrored into `properties` above, deliberately and temporarily. Three
+        # data-pipeline consumers read the old location — `register_per_acquisition.py:132`
+        # (`d["properties"]["renders"]["rgb"]`, a hard KeyError), `register_v1_s1_rtc.py:57` and
+        # `register_v1.py:191` (both `.get`, so they silently lose the render config, which turns
+        # `_reorient_item_to_orbit` into a no-op and ships the wrong orbit's render on every
+        # dual-orbit cube). Moving `renders` without the mirror breaks them the moment the
+        # data-model pin bumps. Drop the mirror once those three read the root.
+        extra_fields={"renders": cube_render},
     )
 
     store_str = str(zarr_store)
@@ -792,11 +809,17 @@ def build_s1_rtc_per_acquisition_items(
         normalized = _normalize_platform(platform)
         if normalized:
             props["platform"] = normalized
-        item_dict["properties"] = props
         # At the item ROOT, not in properties — see the note on the cube item's `extra_fields`.
         # The base item is cloned per acquisition, so this also overrides whatever orbit the cube
-        # chose as preferred.
-        item_dict["renders"] = {"rgb": _rgb_render(orbit)}
+        # chose as preferred. Both copies MUST be overwritten: `props` is inherited from the cube
+        # base, so leaving the mirror alone would leave the *preferred* orbit's render sitting in
+        # `properties` while the root carried this item's — exactly the disagreement the mirror
+        # exists to avoid. Build once and share the object between the two: they are the same
+        # render config, and nothing mutates an item after this loop.
+        render = {"rgb": _rgb_render(orbit)}
+        props["renders"] = render
+        item_dict["properties"] = props
+        item_dict["renders"] = render
 
         # Drop the datacube ext (a single acquisition is not a cube). Ensure the SAT ext is declared:
         # a per-acq item always sets sat:orbit_state, but a dual-orbit cube base omits both.

--- a/tests/_test_data/s1_rtc_examples/regenerate.py
+++ b/tests/_test_data/s1_rtc_examples/regenerate.py
@@ -1,0 +1,146 @@
+"""Regenerate the S1 GRD RTC example JSON from a store built by the current ingester.
+
+Run from the repository root::
+
+    .venv/bin/python tests/_test_data/s1_rtc_examples/regenerate.py
+
+The fixture in this directory is the only thing ``tests/test_data_api/test_s1_rtc.py``
+validates the ``S1RtcRoot`` model against, so a hand-maintained fixture lets the model and
+the writer drift apart silently. That is exactly what happened: the checked-in JSON predated
+both the ``x``/``y``/``spatial_ref`` coordinate arrays and the per-level ``time`` coordinate
+(data-model #192), so ``S1RtcRoot.from_zarr`` raised 23 ``extra_forbidden`` errors on any
+store this repo's own writer produced while every model test stayed green.
+
+This script closes that loop: it drives ``ingest_s1tiling_acquisition`` /
+``ingest_s1tiling_conditions`` / ``consolidate_s1_store`` over synthetic GeoTIFFs and dumps
+the resulting hierarchy with the *generic* ``GroupSpec`` (never ``S1RtcRoot``) — the fixture
+must record what the writer emits, not what the model already accepts.
+
+The synthetic tile mimics the real 31TCH descending cube the original fixture came from
+(EPSG:32631, origin at the MGRS tile corner, 3 acquisitions on relative orbit 110, gamma_area
+for the three orbits that cover the tile) at 1/10 the linear size, so regeneration stays cheap.
+Only metadata reaches the JSON, so the pixel values are irrelevant beyond being well-formed.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import rasterio
+import zarr
+from pydantic_zarr.v3 import GroupSpec
+from rasterio.transform import from_bounds
+
+from eopf_geozarr.conversion.s1_ingest import (
+    consolidate_s1_store,
+    ingest_s1tiling_acquisition,
+    ingest_s1tiling_conditions,
+)
+
+# 31TCH is UTM zone 31N with its north-west corner at (500000, 5000000). The real tile is
+# 10980 px at 10 m; 1080 is a decade-smaller stand-in sharing the corner and the pixel size.
+# The exact value matters: `calculate_aligned_chunk_size` only accepts an inner chunk that
+# divides the level's edge, so every level in the r10m→r720m chain must keep a divisor near
+# 512 (1080 → 540 → 180 → 90 → 30 → 15 does; 1098 → 549 does not, and the shard write raises).
+SIZE = 1080
+PIXEL = 10.0
+CRS = "EPSG:32631"
+XMIN, YMAX = 500000.0, 5000000.0
+TRANSFORM = from_bounds(XMIN, YMAX - SIZE * PIXEL, XMIN + SIZE * PIXEL, YMAX, SIZE, SIZE)
+
+ORBIT_DIRECTION = "descending"
+RELATIVE_ORBIT = 110
+# The three relative orbits whose gamma-area maps cover 31TCH; the original fixture carried
+# all three, and a multi-orbit conditions group is the case worth keeping under test.
+CONDITION_ORBITS = (8, 37, 110)
+
+ACQUISITIONS = (
+    ("2025:02:05T06:01:10Z", 57895),
+    ("2025:02:17T06:01:10Z", 58070),
+    ("2025:03:01T06:01:09Z", 58245),
+)
+
+OUTPUT = Path(__file__).with_name("s1-grd-rtc-31TCH.json")
+
+
+def _tags(acquisition_datetime: str, absolute_orbit: int) -> dict[str, str]:
+    return {
+        "ACQUISITION_DATETIME": acquisition_datetime,
+        "ORBIT_NUMBER": str(absolute_orbit),
+        "RELATIVE_ORBIT_NUMBER": f"{RELATIVE_ORBIT:03d}",
+        "FLYING_UNIT_CODE": "S1A",
+        "CALIBRATION": "gamma_naught",
+        "INPUT_S1_IMAGES": f"S1A_IW_GRDH_1SDV_{acquisition_datetime[:10].replace(':', '')}",
+    }
+
+
+def _write_geotiff(path: Path, data: np.ndarray, tags: dict[str, str] | None = None) -> Path:
+    with rasterio.open(
+        str(path),
+        "w",
+        driver="GTiff",
+        height=data.shape[0],
+        width=data.shape[1],
+        count=1,
+        dtype=data.dtype,
+        crs=CRS,
+        transform=TRANSFORM,
+    ) as dst:
+        if tags:
+            dst.update_tags(**tags)
+        dst.write(data, 1)
+    return path
+
+
+def build_store(work_dir: Path) -> Path:
+    """Ingest synthetic 31TCH GeoTIFFs into a consolidated GeoZarr V3 store."""
+    rng = np.random.default_rng(31031)
+    store_path = work_dir / "s1-grd-rtc-31TCH.zarr"
+
+    for index, (stamp, absolute_orbit) in enumerate(ACQUISITIONS):
+        tags = _tags(stamp, absolute_orbit)
+        prefix = f"s1a_31TCH_DES_{RELATIVE_ORBIT:03d}_{index}"
+        border_mask = np.ones((SIZE, SIZE), dtype=np.uint8)
+        border_mask[:32, :] = 0
+        vv, vh = (
+            _write_geotiff(
+                work_dir / f"{prefix}_{pol}.tif",
+                rng.uniform(0.0, 1.0, (SIZE, SIZE)).astype(np.float32),
+                tags,
+            )
+            for pol in ("vv", "vh")
+        )
+        mask = _write_geotiff(work_dir / f"{prefix}_mask.tif", border_mask, tags)
+        ingest_s1tiling_acquisition(vv, vh, mask, store_path, ORBIT_DIRECTION)
+
+    for orbit in CONDITION_ORBITS:
+        gamma_area = _write_geotiff(
+            work_dir / f"GAMMA_AREA_31TCH_{orbit:03d}.tif",
+            rng.uniform(0.5, 2.0, (SIZE, SIZE)).astype(np.float32),
+        )
+        ingest_s1tiling_conditions(
+            store_path=store_path,
+            orbit_direction=ORBIT_DIRECTION,
+            relative_orbit=orbit,
+            gamma_area_path=gamma_area,
+        )
+
+    consolidate_s1_store(store_path, ORBIT_DIRECTION)
+    return store_path
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        store_path = build_store(Path(tmp))
+        root = zarr.open_group(str(store_path), mode="r", zarr_format=3)
+        # The *generic* GroupSpec, never S1RtcRoot: the fixture must record what the writer
+        # emits, not what the model already accepts, or the drift this closes reopens.
+        spec = GroupSpec.from_zarr(root)
+
+    OUTPUT.write_text(json.dumps(spec.model_dump(mode="json"), indent=2) + "\n")
+    print(f"Wrote {OUTPUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/_test_data/s1_rtc_examples/s1-grd-rtc-31TCH.json
+++ b/tests/_test_data/s1_rtc_examples/s1-grd-rtc-31TCH.json
@@ -1,31 +1,58 @@
 {
   "zarr_format": 3,
-  "attributes": {},
+  "node_type": "group",
+  "attributes": {
+    "zarr_conventions": [
+      {
+        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+        "name": "spatial:",
+        "description": "Spatial coordinate information"
+      },
+      {
+        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+        "name": "proj:",
+        "description": "Coordinate reference system information for geospatial data"
+      }
+    ],
+    "proj:code": "EPSG:4326",
+    "spatial:bbox": [
+      2.9999999999999916,
+      45.05617579675385,
+      3.1373963412819053,
+      45.153477183356024
+    ],
+    "eopf:writer_schema": 2
+  },
   "members": {
     "descending": {
       "zarr_format": 3,
+      "node_type": "group",
       "attributes": {
         "zarr_conventions": [
           {
             "uuid": "d35379db-88df-4056-af3a-620245f8e347",
+            "schema_url": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v0.1/schema.json",
+            "spec_url": "https://github.com/zarr-conventions/multiscales/blob/v0.1/README.md",
             "name": "multiscales",
-            "schema_url": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v1/schema.json",
-            "spec_url": "https://github.com/zarr-conventions/multiscales/blob/v1/README.md",
-            "description": "Multiscale layout"
+            "description": "Multiscale layout of zarr datasets"
           },
           {
             "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+            "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+            "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
             "name": "proj:",
-            "schema_url": "https://raw.githubusercontent.com/zarr-experimental/geo-proj/refs/tags/v1/schema.json",
-            "spec_url": "https://github.com/zarr-experimental/geo-proj/blob/v1/README.md",
-            "description": "CRS"
+            "description": "Coordinate reference system information for geospatial data"
           },
           {
             "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+            "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+            "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
             "name": "spatial:",
-            "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/refs/tags/v1/schema.json",
-            "spec_url": "https://github.com/zarr-conventions/spatial/blob/v1/README.md",
-            "description": "Spatial coordinates"
+            "description": "Spatial coordinate information"
           }
         ],
         "multiscales": {
@@ -33,8 +60,8 @@
             {
               "asset": "r10m",
               "spatial:shape": [
-                10980,
-                10980
+                1080,
+                1080
               ],
               "spatial:transform": [
                 10.0,
@@ -54,8 +81,8 @@
             {
               "asset": "r20m",
               "spatial:shape": [
-                5490,
-                5490
+                540,
+                540
               ],
               "spatial:transform": [
                 20.0,
@@ -80,8 +107,8 @@
             {
               "asset": "r60m",
               "spatial:shape": [
-                1830,
-                1830
+                180,
+                180
               ],
               "spatial:transform": [
                 60.0,
@@ -106,8 +133,8 @@
             {
               "asset": "r120m",
               "spatial:shape": [
-                915,
-                915
+                90,
+                90
               ],
               "spatial:transform": [
                 120.0,
@@ -132,8 +159,8 @@
             {
               "asset": "r360m",
               "spatial:shape": [
-                305,
-                305
+                30,
+                30
               ],
               "spatial:transform": [
                 360.0,
@@ -158,8 +185,8 @@
             {
               "asset": "r720m",
               "spatial:shape": [
-                153,
-                153
+                15,
+                15
               ],
               "spatial:transform": [
                 720.0,
@@ -191,18 +218,19 @@
         ],
         "spatial:bbox": [
           500000.0,
-          4890200.0,
-          609800.0,
+          4989200.0,
+          510800.0,
           5000000.0
         ]
       },
       "members": {
-        "r10m": {
+        "conditions": {
           "zarr_format": 3,
+          "node_type": "group",
           "attributes": {
-            "spatial:shape": [
-              10980,
-              10980
+            "spatial:dimensions": [
+              "y",
+              "x"
             ],
             "spatial:transform": [
               10.0,
@@ -211,26 +239,48 @@
               0.0,
               -10.0,
               5000000.0
-            ]
+            ],
+            "spatial:shape": [
+              1080,
+              1080
+            ],
+            "zarr_conventions": [
+              {
+                "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                "name": "spatial:",
+                "description": "Spatial coordinate information"
+              },
+              {
+                "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                "name": "proj:",
+                "description": "Coordinate reference system information for geospatial data"
+              }
+            ],
+            "proj:code": "EPSG:32631"
           },
           "members": {
-            "vv": {
+            "gamma_area_008": {
               "zarr_format": 3,
               "node_type": "array",
-              "attributes": {},
+              "attributes": {
+                "_FillValue": "AAAAAAAA+H8=",
+                "grid_mapping": "spatial_ref"
+              },
               "shape": [
-                3,
-                10980,
-                10980
+                1080,
+                1080
               ],
               "data_type": "float32",
               "chunk_grid": {
                 "name": "regular",
                 "configuration": {
                   "chunk_shape": [
-                    1,
-                    10980,
-                    10980
+                    1080,
+                    1080
                   ]
                 }
               },
@@ -246,9 +296,8 @@
                   "name": "sharding_indexed",
                   "configuration": {
                     "chunk_shape": [
-                      1,
-                      366,
-                      366
+                      360,
+                      360
                     ],
                     "codecs": [
                       {
@@ -260,8 +309,11 @@
                       {
                         "name": "blosc",
                         "configuration": {
+                          "typesize": 4,
                           "cname": "zstd",
-                          "clevel": 5
+                          "clevel": 5,
+                          "shuffle": "shuffle",
+                          "blocksize": 0
                         }
                       }
                     ],
@@ -282,28 +334,28 @@
               ],
               "storage_transformers": [],
               "dimension_names": [
-                "time",
                 "y",
                 "x"
               ]
             },
-            "vh": {
+            "gamma_area_037": {
               "zarr_format": 3,
               "node_type": "array",
-              "attributes": {},
+              "attributes": {
+                "_FillValue": "AAAAAAAA+H8=",
+                "grid_mapping": "spatial_ref"
+              },
               "shape": [
-                3,
-                10980,
-                10980
+                1080,
+                1080
               ],
               "data_type": "float32",
               "chunk_grid": {
                 "name": "regular",
                 "configuration": {
                   "chunk_shape": [
-                    1,
-                    10980,
-                    10980
+                    1080,
+                    1080
                   ]
                 }
               },
@@ -319,9 +371,8 @@
                   "name": "sharding_indexed",
                   "configuration": {
                     "chunk_shape": [
-                      1,
-                      366,
-                      366
+                      360,
+                      360
                     ],
                     "codecs": [
                       {
@@ -333,8 +384,11 @@
                       {
                         "name": "blosc",
                         "configuration": {
+                          "typesize": 4,
                           "cname": "zstd",
-                          "clevel": 5
+                          "clevel": 5,
+                          "shuffle": "shuffle",
+                          "blocksize": 0
                         }
                       }
                     ],
@@ -355,28 +409,28 @@
               ],
               "storage_transformers": [],
               "dimension_names": [
-                "time",
                 "y",
                 "x"
               ]
             },
-            "border_mask": {
+            "gamma_area_110": {
               "zarr_format": 3,
               "node_type": "array",
-              "attributes": {},
+              "attributes": {
+                "_FillValue": "AAAAAAAA+H8=",
+                "grid_mapping": "spatial_ref"
+              },
               "shape": [
-                3,
-                10980,
-                10980
+                1080,
+                1080
               ],
-              "data_type": "uint8",
+              "data_type": "float32",
               "chunk_grid": {
                 "name": "regular",
                 "configuration": {
                   "chunk_shape": [
-                    1,
-                    10980,
-                    10980
+                    1080,
+                    1080
                   ]
                 }
               },
@@ -386,15 +440,14 @@
                   "separator": "/"
                 }
               },
-              "fill_value": 0,
+              "fill_value": "NaN",
               "codecs": [
                 {
                   "name": "sharding_indexed",
                   "configuration": {
                     "chunk_shape": [
-                      1,
-                      366,
-                      366
+                      360,
+                      360
                     ],
                     "codecs": [
                       {
@@ -406,8 +459,11 @@
                       {
                         "name": "blosc",
                         "configuration": {
+                          "typesize": 4,
                           "cname": "zstd",
-                          "clevel": 5
+                          "clevel": 5,
+                          "shuffle": "shuffle",
+                          "blocksize": 0
                         }
                       }
                     ],
@@ -428,25 +484,39 @@
               ],
               "storage_transformers": [],
               "dimension_names": [
-                "time",
                 "y",
                 "x"
               ]
             },
-            "time": {
+            "spatial_ref": {
               "zarr_format": 3,
               "node_type": "array",
-              "attributes": {},
-              "shape": [
-                3
-              ],
+              "attributes": {
+                "crs_wkt": "PROJCRS[\"WGS 84 / UTM zone 31N\",BASEGEOGCRS[\"WGS 84\",ENSEMBLE[\"World Geodetic System 1984 ensemble\",MEMBER[\"World Geodetic System 1984 (Transit)\"],MEMBER[\"World Geodetic System 1984 (G730)\"],MEMBER[\"World Geodetic System 1984 (G873)\"],MEMBER[\"World Geodetic System 1984 (G1150)\"],MEMBER[\"World Geodetic System 1984 (G1674)\"],MEMBER[\"World Geodetic System 1984 (G1762)\"],MEMBER[\"World Geodetic System 1984 (G2139)\"],MEMBER[\"World Geodetic System 1984 (G2296)\"],ELLIPSOID[\"WGS 84\",6378137,298.257223563,LENGTHUNIT[\"metre\",1]],ENSEMBLEACCURACY[2.0]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433]],ID[\"EPSG\",4326]],CONVERSION[\"UTM zone 31N\",METHOD[\"Transverse Mercator\",ID[\"EPSG\",9807]],PARAMETER[\"Latitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8801]],PARAMETER[\"Longitude of natural origin\",3,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"Scale factor at natural origin\",0.9996,SCALEUNIT[\"unity\",1],ID[\"EPSG\",8805]],PARAMETER[\"False easting\",500000,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"(E)\",east,ORDER[1],LENGTHUNIT[\"metre\",1]],AXIS[\"(N)\",north,ORDER[2],LENGTHUNIT[\"metre\",1]],USAGE[SCOPE[\"Navigation and medium accuracy spatial referencing.\"],AREA[\"Between 0\u00b0E and 6\u00b0E, northern hemisphere between equator and 84\u00b0N, onshore and offshore. Algeria. Andorra. Belgium. Benin. Burkina Faso. Denmark - North Sea. France. Germany - North Sea. Ghana. Luxembourg. Mali. Netherlands. Niger. Nigeria. Norway. Spain. Togo. United Kingdom (UK) - North Sea.\"],BBOX[0,0,84,6]],ID[\"EPSG\",32631]]",
+                "semi_major_axis": 6378137.0,
+                "semi_minor_axis": 6356752.314245179,
+                "inverse_flattening": 298.257223563,
+                "reference_ellipsoid_name": "WGS 84",
+                "longitude_of_prime_meridian": 0.0,
+                "prime_meridian_name": "Greenwich",
+                "geographic_crs_name": "WGS 84",
+                "horizontal_datum_name": "World Geodetic System 1984 ensemble",
+                "projected_crs_name": "WGS 84 / UTM zone 31N",
+                "grid_mapping_name": "transverse_mercator",
+                "latitude_of_projection_origin": 0.0,
+                "longitude_of_central_meridian": 3.0,
+                "false_easting": 500000.0,
+                "false_northing": 0.0,
+                "scale_factor_at_central_meridian": 0.9996,
+                "spatial_ref": "PROJCRS[\"WGS 84 / UTM zone 31N\",BASEGEOGCRS[\"WGS 84\",ENSEMBLE[\"World Geodetic System 1984 ensemble\",MEMBER[\"World Geodetic System 1984 (Transit)\"],MEMBER[\"World Geodetic System 1984 (G730)\"],MEMBER[\"World Geodetic System 1984 (G873)\"],MEMBER[\"World Geodetic System 1984 (G1150)\"],MEMBER[\"World Geodetic System 1984 (G1674)\"],MEMBER[\"World Geodetic System 1984 (G1762)\"],MEMBER[\"World Geodetic System 1984 (G2139)\"],MEMBER[\"World Geodetic System 1984 (G2296)\"],ELLIPSOID[\"WGS 84\",6378137,298.257223563,LENGTHUNIT[\"metre\",1]],ENSEMBLEACCURACY[2.0]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433]],ID[\"EPSG\",4326]],CONVERSION[\"UTM zone 31N\",METHOD[\"Transverse Mercator\",ID[\"EPSG\",9807]],PARAMETER[\"Latitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8801]],PARAMETER[\"Longitude of natural origin\",3,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"Scale factor at natural origin\",0.9996,SCALEUNIT[\"unity\",1],ID[\"EPSG\",8805]],PARAMETER[\"False easting\",500000,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"(E)\",east,ORDER[1],LENGTHUNIT[\"metre\",1]],AXIS[\"(N)\",north,ORDER[2],LENGTHUNIT[\"metre\",1]],USAGE[SCOPE[\"Navigation and medium accuracy spatial referencing.\"],AREA[\"Between 0\u00b0E and 6\u00b0E, northern hemisphere between equator and 84\u00b0N, onshore and offshore. Algeria. Andorra. Belgium. Benin. Burkina Faso. Denmark - North Sea. France. Germany - North Sea. Ghana. Luxembourg. Mali. Netherlands. Niger. Nigeria. Norway. Spain. Togo. United Kingdom (UK) - North Sea.\"],BBOX[0,0,84,6]],ID[\"EPSG\",32631]]",
+                "_ARRAY_DIMENSIONS": []
+              },
+              "shape": [],
               "data_type": "int64",
               "chunk_grid": {
                 "name": "regular",
                 "configuration": {
-                  "chunk_shape": [
-                    512
-                  ]
+                  "chunk_shape": []
                 }
               },
               "chunk_key_encoding": {
@@ -462,13 +532,159 @@
                   "configuration": {
                     "endian": "little"
                   }
+                },
+                {
+                  "name": "zstd",
+                  "configuration": {
+                    "level": 0,
+                    "checksum": false
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": null
+            },
+            "x": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "units": "m",
+                "long_name": "x coordinate of projection",
+                "standard_name": "projection_x_coordinate",
+                "_ARRAY_DIMENSIONS": [
+                  "x"
+                ]
+              },
+              "shape": [
+                1080
+              ],
+              "data_type": "float64",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": [
+                    1080
+                  ]
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": "NaN",
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "zstd",
+                  "configuration": {
+                    "level": 0,
+                    "checksum": false
+                  }
                 }
               ],
               "storage_transformers": [],
               "dimension_names": [
-                "time"
+                "x"
               ]
             },
+            "y": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "units": "m",
+                "long_name": "y coordinate of projection",
+                "standard_name": "projection_y_coordinate",
+                "_ARRAY_DIMENSIONS": [
+                  "y"
+                ]
+              },
+              "shape": [
+                1080
+              ],
+              "data_type": "float64",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": [
+                    1080
+                  ]
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": "NaN",
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "zstd",
+                  "configuration": {
+                    "level": 0,
+                    "checksum": false
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": [
+                "y"
+              ]
+            }
+          }
+        },
+        "r10m": {
+          "zarr_format": 3,
+          "node_type": "group",
+          "attributes": {
+            "spatial:dimensions": [
+              "y",
+              "x"
+            ],
+            "spatial:shape": [
+              1080,
+              1080
+            ],
+            "spatial:transform": [
+              10.0,
+              0.0,
+              500000.0,
+              0.0,
+              -10.0,
+              5000000.0
+            ],
+            "zarr_conventions": [
+              {
+                "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                "name": "spatial:",
+                "description": "Spatial coordinate information"
+              },
+              {
+                "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                "name": "proj:",
+                "description": "Coordinate reference system information for geospatial data"
+              }
+            ],
+            "proj:code": "EPSG:32631"
+          },
+          "members": {
             "absolute_orbit": {
               "zarr_format": 3,
               "node_type": "array",
@@ -497,6 +713,136 @@
                   "name": "bytes",
                   "configuration": {
                     "endian": "little"
+                  }
+                },
+                {
+                  "name": "zstd",
+                  "configuration": {
+                    "level": 0,
+                    "checksum": false
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": [
+                "time"
+              ]
+            },
+            "border_mask": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "grid_mapping": "spatial_ref"
+              },
+              "shape": [
+                3,
+                1080,
+                1080
+              ],
+              "data_type": "uint8",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": [
+                    1,
+                    1080,
+                    1080
+                  ]
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": 0,
+              "codecs": [
+                {
+                  "name": "sharding_indexed",
+                  "configuration": {
+                    "chunk_shape": [
+                      1,
+                      360,
+                      360
+                    ],
+                    "codecs": [
+                      {
+                        "name": "bytes"
+                      },
+                      {
+                        "name": "blosc",
+                        "configuration": {
+                          "typesize": 1,
+                          "cname": "zstd",
+                          "clevel": 5,
+                          "shuffle": "bitshuffle",
+                          "blocksize": 0
+                        }
+                      }
+                    ],
+                    "index_codecs": [
+                      {
+                        "name": "bytes",
+                        "configuration": {
+                          "endian": "little"
+                        }
+                      },
+                      {
+                        "name": "crc32c"
+                      }
+                    ],
+                    "index_location": "end"
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": [
+                "time",
+                "y",
+                "x"
+              ]
+            },
+            "platform": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {},
+              "shape": [
+                3
+              ],
+              "data_type": {
+                "name": "fixed_length_utf32",
+                "configuration": {
+                  "length_bytes": 16
+                }
+              },
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": [
+                    512
+                  ]
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": "",
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "zstd",
+                  "configuration": {
+                    "level": 0,
+                    "checksum": false
                   }
                 }
               ],
@@ -534,6 +880,13 @@
                   "configuration": {
                     "endian": "little"
                   }
+                },
+                {
+                  "name": "zstd",
+                  "configuration": {
+                    "level": 0,
+                    "checksum": false
+                  }
                 }
               ],
               "storage_transformers": [],
@@ -541,14 +894,77 @@
                 "time"
               ]
             },
-            "platform": {
+            "spatial_ref": {
               "zarr_format": 3,
               "node_type": "array",
-              "attributes": {},
+              "attributes": {
+                "crs_wkt": "PROJCRS[\"WGS 84 / UTM zone 31N\",BASEGEOGCRS[\"WGS 84\",ENSEMBLE[\"World Geodetic System 1984 ensemble\",MEMBER[\"World Geodetic System 1984 (Transit)\"],MEMBER[\"World Geodetic System 1984 (G730)\"],MEMBER[\"World Geodetic System 1984 (G873)\"],MEMBER[\"World Geodetic System 1984 (G1150)\"],MEMBER[\"World Geodetic System 1984 (G1674)\"],MEMBER[\"World Geodetic System 1984 (G1762)\"],MEMBER[\"World Geodetic System 1984 (G2139)\"],MEMBER[\"World Geodetic System 1984 (G2296)\"],ELLIPSOID[\"WGS 84\",6378137,298.257223563,LENGTHUNIT[\"metre\",1]],ENSEMBLEACCURACY[2.0]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433]],ID[\"EPSG\",4326]],CONVERSION[\"UTM zone 31N\",METHOD[\"Transverse Mercator\",ID[\"EPSG\",9807]],PARAMETER[\"Latitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8801]],PARAMETER[\"Longitude of natural origin\",3,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"Scale factor at natural origin\",0.9996,SCALEUNIT[\"unity\",1],ID[\"EPSG\",8805]],PARAMETER[\"False easting\",500000,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"(E)\",east,ORDER[1],LENGTHUNIT[\"metre\",1]],AXIS[\"(N)\",north,ORDER[2],LENGTHUNIT[\"metre\",1]],USAGE[SCOPE[\"Navigation and medium accuracy spatial referencing.\"],AREA[\"Between 0\u00b0E and 6\u00b0E, northern hemisphere between equator and 84\u00b0N, onshore and offshore. Algeria. Andorra. Belgium. Benin. Burkina Faso. Denmark - North Sea. France. Germany - North Sea. Ghana. Luxembourg. Mali. Netherlands. Niger. Nigeria. Norway. Spain. Togo. United Kingdom (UK) - North Sea.\"],BBOX[0,0,84,6]],ID[\"EPSG\",32631]]",
+                "semi_major_axis": 6378137.0,
+                "semi_minor_axis": 6356752.314245179,
+                "inverse_flattening": 298.257223563,
+                "reference_ellipsoid_name": "WGS 84",
+                "longitude_of_prime_meridian": 0.0,
+                "prime_meridian_name": "Greenwich",
+                "geographic_crs_name": "WGS 84",
+                "horizontal_datum_name": "World Geodetic System 1984 ensemble",
+                "projected_crs_name": "WGS 84 / UTM zone 31N",
+                "grid_mapping_name": "transverse_mercator",
+                "latitude_of_projection_origin": 0.0,
+                "longitude_of_central_meridian": 3.0,
+                "false_easting": 500000.0,
+                "false_northing": 0.0,
+                "scale_factor_at_central_meridian": 0.9996,
+                "spatial_ref": "PROJCRS[\"WGS 84 / UTM zone 31N\",BASEGEOGCRS[\"WGS 84\",ENSEMBLE[\"World Geodetic System 1984 ensemble\",MEMBER[\"World Geodetic System 1984 (Transit)\"],MEMBER[\"World Geodetic System 1984 (G730)\"],MEMBER[\"World Geodetic System 1984 (G873)\"],MEMBER[\"World Geodetic System 1984 (G1150)\"],MEMBER[\"World Geodetic System 1984 (G1674)\"],MEMBER[\"World Geodetic System 1984 (G1762)\"],MEMBER[\"World Geodetic System 1984 (G2139)\"],MEMBER[\"World Geodetic System 1984 (G2296)\"],ELLIPSOID[\"WGS 84\",6378137,298.257223563,LENGTHUNIT[\"metre\",1]],ENSEMBLEACCURACY[2.0]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433]],ID[\"EPSG\",4326]],CONVERSION[\"UTM zone 31N\",METHOD[\"Transverse Mercator\",ID[\"EPSG\",9807]],PARAMETER[\"Latitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8801]],PARAMETER[\"Longitude of natural origin\",3,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"Scale factor at natural origin\",0.9996,SCALEUNIT[\"unity\",1],ID[\"EPSG\",8805]],PARAMETER[\"False easting\",500000,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"(E)\",east,ORDER[1],LENGTHUNIT[\"metre\",1]],AXIS[\"(N)\",north,ORDER[2],LENGTHUNIT[\"metre\",1]],USAGE[SCOPE[\"Navigation and medium accuracy spatial referencing.\"],AREA[\"Between 0\u00b0E and 6\u00b0E, northern hemisphere between equator and 84\u00b0N, onshore and offshore. Algeria. Andorra. Belgium. Benin. Burkina Faso. Denmark - North Sea. France. Germany - North Sea. Ghana. Luxembourg. Mali. Netherlands. Niger. Nigeria. Norway. Spain. Togo. United Kingdom (UK) - North Sea.\"],BBOX[0,0,84,6]],ID[\"EPSG\",32631]]",
+                "_ARRAY_DIMENSIONS": []
+              },
+              "shape": [],
+              "data_type": "int64",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": []
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": 0,
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "zstd",
+                  "configuration": {
+                    "level": 0,
+                    "checksum": false
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": null
+            },
+            "time": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "units": "nanoseconds since 1970-01-01",
+                "calendar": "proleptic_gregorian",
+                "standard_name": "time",
+                "_ARRAY_DIMENSIONS": [
+                  "time"
+                ]
+              },
               "shape": [
                 3
               ],
-              "data_type": "<U4",
+              "data_type": "int64",
               "chunk_grid": {
                 "name": "regular",
                 "configuration": {
@@ -563,12 +979,19 @@
                   "separator": "/"
                 }
               },
-              "fill_value": "",
+              "fill_value": 0,
               "codecs": [
                 {
                   "name": "bytes",
                   "configuration": {
                     "endian": "little"
+                  }
+                },
+                {
+                  "name": "zstd",
+                  "configuration": {
+                    "level": 0,
+                    "checksum": false
                   }
                 }
               ],
@@ -576,107 +999,20 @@
               "dimension_names": [
                 "time"
               ]
-            }
-          }
-        },
-        "r20m": {
-          "zarr_format": 3,
-          "attributes": {
-            "spatial:shape": [
-              5490,
-              5490
-            ],
-            "spatial:transform": [
-              20.0,
-              0.0,
-              500000.0,
-              0.0,
-              -20.0,
-              5000000.0
-            ]
-          },
-          "members": {
-            "vv": {
-              "zarr_format": 3,
-              "node_type": "array",
-              "attributes": {},
-              "shape": [
-                3,
-                5490,
-                5490
-              ],
-              "data_type": "float32",
-              "chunk_grid": {
-                "name": "regular",
-                "configuration": {
-                  "chunk_shape": [
-                    1,
-                    5490,
-                    5490
-                  ]
-                }
-              },
-              "chunk_key_encoding": {
-                "name": "default",
-                "configuration": {
-                  "separator": "/"
-                }
-              },
-              "fill_value": "NaN",
-              "codecs": [
-                {
-                  "name": "sharding_indexed",
-                  "configuration": {
-                    "chunk_shape": [
-                      1,
-                      366,
-                      366
-                    ],
-                    "codecs": [
-                      {
-                        "name": "bytes",
-                        "configuration": {
-                          "endian": "little"
-                        }
-                      },
-                      {
-                        "name": "blosc",
-                        "configuration": {
-                          "cname": "zstd",
-                          "clevel": 5
-                        }
-                      }
-                    ],
-                    "index_codecs": [
-                      {
-                        "name": "bytes",
-                        "configuration": {
-                          "endian": "little"
-                        }
-                      },
-                      {
-                        "name": "crc32c"
-                      }
-                    ],
-                    "index_location": "end"
-                  }
-                }
-              ],
-              "storage_transformers": [],
-              "dimension_names": [
-                "time",
-                "y",
-                "x"
-              ]
             },
             "vh": {
               "zarr_format": 3,
               "node_type": "array",
-              "attributes": {},
+              "attributes": {
+                "standard_name": "surface_backwards_scattering_coefficient_of_radar_wave",
+                "units": "1",
+                "_FillValue": "AAAAAAAA+H8=",
+                "grid_mapping": "spatial_ref"
+              },
               "shape": [
                 3,
-                5490,
-                5490
+                1080,
+                1080
               ],
               "data_type": "float32",
               "chunk_grid": {
@@ -684,8 +1020,8 @@
                 "configuration": {
                   "chunk_shape": [
                     1,
-                    5490,
-                    5490
+                    1080,
+                    1080
                   ]
                 }
               },
@@ -702,8 +1038,8 @@
                   "configuration": {
                     "chunk_shape": [
                       1,
-                      366,
-                      366
+                      360,
+                      360
                     ],
                     "codecs": [
                       {
@@ -715,8 +1051,11 @@
                       {
                         "name": "blosc",
                         "configuration": {
+                          "typesize": 4,
                           "cname": "zstd",
-                          "clevel": 5
+                          "clevel": 5,
+                          "shuffle": "shuffle",
+                          "blocksize": 0
                         }
                       }
                     ],
@@ -742,106 +1081,19 @@
                 "x"
               ]
             },
-            "border_mask": {
-              "zarr_format": 3,
-              "node_type": "array",
-              "attributes": {},
-              "shape": [
-                3,
-                5490,
-                5490
-              ],
-              "data_type": "uint8",
-              "chunk_grid": {
-                "name": "regular",
-                "configuration": {
-                  "chunk_shape": [
-                    1,
-                    5490,
-                    5490
-                  ]
-                }
-              },
-              "chunk_key_encoding": {
-                "name": "default",
-                "configuration": {
-                  "separator": "/"
-                }
-              },
-              "fill_value": 0,
-              "codecs": [
-                {
-                  "name": "sharding_indexed",
-                  "configuration": {
-                    "chunk_shape": [
-                      1,
-                      366,
-                      366
-                    ],
-                    "codecs": [
-                      {
-                        "name": "bytes",
-                        "configuration": {
-                          "endian": "little"
-                        }
-                      },
-                      {
-                        "name": "blosc",
-                        "configuration": {
-                          "cname": "zstd",
-                          "clevel": 5
-                        }
-                      }
-                    ],
-                    "index_codecs": [
-                      {
-                        "name": "bytes",
-                        "configuration": {
-                          "endian": "little"
-                        }
-                      },
-                      {
-                        "name": "crc32c"
-                      }
-                    ],
-                    "index_location": "end"
-                  }
-                }
-              ],
-              "storage_transformers": [],
-              "dimension_names": [
-                "time",
-                "y",
-                "x"
-              ]
-            }
-          }
-        },
-        "r60m": {
-          "zarr_format": 3,
-          "attributes": {
-            "spatial:shape": [
-              1830,
-              1830
-            ],
-            "spatial:transform": [
-              60.0,
-              0.0,
-              500000.0,
-              0.0,
-              -60.0,
-              5000000.0
-            ]
-          },
-          "members": {
             "vv": {
               "zarr_format": 3,
               "node_type": "array",
-              "attributes": {},
+              "attributes": {
+                "standard_name": "surface_backwards_scattering_coefficient_of_radar_wave",
+                "units": "1",
+                "_FillValue": "AAAAAAAA+H8=",
+                "grid_mapping": "spatial_ref"
+              },
               "shape": [
                 3,
-                1830,
-                1830
+                1080,
+                1080
               ],
               "data_type": "float32",
               "chunk_grid": {
@@ -849,8 +1101,8 @@
                 "configuration": {
                   "chunk_shape": [
                     1,
-                    1830,
-                    1830
+                    1080,
+                    1080
                   ]
                 }
               },
@@ -867,8 +1119,8 @@
                   "configuration": {
                     "chunk_shape": [
                       1,
-                      366,
-                      366
+                      360,
+                      360
                     ],
                     "codecs": [
                       {
@@ -880,8 +1132,11 @@
                       {
                         "name": "blosc",
                         "configuration": {
+                          "typesize": 4,
                           "cname": "zstd",
-                          "clevel": 5
+                          "clevel": 5,
+                          "shuffle": "shuffle",
+                          "blocksize": 0
                         }
                       }
                     ],
@@ -907,23 +1162,26 @@
                 "x"
               ]
             },
-            "vh": {
+            "x": {
               "zarr_format": 3,
               "node_type": "array",
-              "attributes": {},
+              "attributes": {
+                "units": "m",
+                "long_name": "x coordinate of projection",
+                "standard_name": "projection_x_coordinate",
+                "_ARRAY_DIMENSIONS": [
+                  "x"
+                ]
+              },
               "shape": [
-                3,
-                1830,
-                1830
+                1080
               ],
-              "data_type": "float32",
+              "data_type": "float64",
               "chunk_grid": {
                 "name": "regular",
                 "configuration": {
                   "chunk_shape": [
-                    1,
-                    1830,
-                    1830
+                    1080
                   ]
                 }
               },
@@ -936,67 +1194,44 @@
               "fill_value": "NaN",
               "codecs": [
                 {
-                  "name": "sharding_indexed",
+                  "name": "bytes",
                   "configuration": {
-                    "chunk_shape": [
-                      1,
-                      366,
-                      366
-                    ],
-                    "codecs": [
-                      {
-                        "name": "bytes",
-                        "configuration": {
-                          "endian": "little"
-                        }
-                      },
-                      {
-                        "name": "blosc",
-                        "configuration": {
-                          "cname": "zstd",
-                          "clevel": 5
-                        }
-                      }
-                    ],
-                    "index_codecs": [
-                      {
-                        "name": "bytes",
-                        "configuration": {
-                          "endian": "little"
-                        }
-                      },
-                      {
-                        "name": "crc32c"
-                      }
-                    ],
-                    "index_location": "end"
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "zstd",
+                  "configuration": {
+                    "level": 0,
+                    "checksum": false
                   }
                 }
               ],
               "storage_transformers": [],
               "dimension_names": [
-                "time",
-                "y",
                 "x"
               ]
             },
-            "border_mask": {
+            "y": {
               "zarr_format": 3,
               "node_type": "array",
-              "attributes": {},
+              "attributes": {
+                "units": "m",
+                "long_name": "y coordinate of projection",
+                "standard_name": "projection_y_coordinate",
+                "_ARRAY_DIMENSIONS": [
+                  "y"
+                ]
+              },
               "shape": [
-                3,
-                1830,
-                1830
+                1080
               ],
-              "data_type": "uint8",
+              "data_type": "float64",
               "chunk_grid": {
                 "name": "regular",
                 "configuration": {
                   "chunk_shape": [
-                    1,
-                    1830,
-                    1830
+                    1080
                   ]
                 }
               },
@@ -1006,61 +1241,40 @@
                   "separator": "/"
                 }
               },
-              "fill_value": 0,
+              "fill_value": "NaN",
               "codecs": [
                 {
-                  "name": "sharding_indexed",
+                  "name": "bytes",
                   "configuration": {
-                    "chunk_shape": [
-                      1,
-                      366,
-                      366
-                    ],
-                    "codecs": [
-                      {
-                        "name": "bytes",
-                        "configuration": {
-                          "endian": "little"
-                        }
-                      },
-                      {
-                        "name": "blosc",
-                        "configuration": {
-                          "cname": "zstd",
-                          "clevel": 5
-                        }
-                      }
-                    ],
-                    "index_codecs": [
-                      {
-                        "name": "bytes",
-                        "configuration": {
-                          "endian": "little"
-                        }
-                      },
-                      {
-                        "name": "crc32c"
-                      }
-                    ],
-                    "index_location": "end"
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "zstd",
+                  "configuration": {
+                    "level": 0,
+                    "checksum": false
                   }
                 }
               ],
               "storage_transformers": [],
               "dimension_names": [
-                "time",
-                "y",
-                "x"
+                "y"
               ]
             }
           }
         },
         "r120m": {
           "zarr_format": 3,
+          "node_type": "group",
           "attributes": {
+            "spatial:dimensions": [
+              "y",
+              "x"
+            ],
             "spatial:shape": [
-              915,
-              915
+              90,
+              90
             ],
             "spatial:transform": [
               120.0,
@@ -1069,163 +1283,36 @@
               0.0,
               -120.0,
               5000000.0
-            ]
+            ],
+            "zarr_conventions": [
+              {
+                "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                "name": "spatial:",
+                "description": "Spatial coordinate information"
+              },
+              {
+                "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                "name": "proj:",
+                "description": "Coordinate reference system information for geospatial data"
+              }
+            ],
+            "proj:code": "EPSG:32631"
           },
           "members": {
-            "vv": {
-              "zarr_format": 3,
-              "node_type": "array",
-              "attributes": {},
-              "shape": [
-                3,
-                915,
-                915
-              ],
-              "data_type": "float32",
-              "chunk_grid": {
-                "name": "regular",
-                "configuration": {
-                  "chunk_shape": [
-                    1,
-                    915,
-                    915
-                  ]
-                }
-              },
-              "chunk_key_encoding": {
-                "name": "default",
-                "configuration": {
-                  "separator": "/"
-                }
-              },
-              "fill_value": "NaN",
-              "codecs": [
-                {
-                  "name": "sharding_indexed",
-                  "configuration": {
-                    "chunk_shape": [
-                      1,
-                      305,
-                      305
-                    ],
-                    "codecs": [
-                      {
-                        "name": "bytes",
-                        "configuration": {
-                          "endian": "little"
-                        }
-                      },
-                      {
-                        "name": "blosc",
-                        "configuration": {
-                          "cname": "zstd",
-                          "clevel": 5
-                        }
-                      }
-                    ],
-                    "index_codecs": [
-                      {
-                        "name": "bytes",
-                        "configuration": {
-                          "endian": "little"
-                        }
-                      },
-                      {
-                        "name": "crc32c"
-                      }
-                    ],
-                    "index_location": "end"
-                  }
-                }
-              ],
-              "storage_transformers": [],
-              "dimension_names": [
-                "time",
-                "y",
-                "x"
-              ]
-            },
-            "vh": {
-              "zarr_format": 3,
-              "node_type": "array",
-              "attributes": {},
-              "shape": [
-                3,
-                915,
-                915
-              ],
-              "data_type": "float32",
-              "chunk_grid": {
-                "name": "regular",
-                "configuration": {
-                  "chunk_shape": [
-                    1,
-                    915,
-                    915
-                  ]
-                }
-              },
-              "chunk_key_encoding": {
-                "name": "default",
-                "configuration": {
-                  "separator": "/"
-                }
-              },
-              "fill_value": "NaN",
-              "codecs": [
-                {
-                  "name": "sharding_indexed",
-                  "configuration": {
-                    "chunk_shape": [
-                      1,
-                      305,
-                      305
-                    ],
-                    "codecs": [
-                      {
-                        "name": "bytes",
-                        "configuration": {
-                          "endian": "little"
-                        }
-                      },
-                      {
-                        "name": "blosc",
-                        "configuration": {
-                          "cname": "zstd",
-                          "clevel": 5
-                        }
-                      }
-                    ],
-                    "index_codecs": [
-                      {
-                        "name": "bytes",
-                        "configuration": {
-                          "endian": "little"
-                        }
-                      },
-                      {
-                        "name": "crc32c"
-                      }
-                    ],
-                    "index_location": "end"
-                  }
-                }
-              ],
-              "storage_transformers": [],
-              "dimension_names": [
-                "time",
-                "y",
-                "x"
-              ]
-            },
             "border_mask": {
               "zarr_format": 3,
               "node_type": "array",
-              "attributes": {},
+              "attributes": {
+                "grid_mapping": "spatial_ref"
+              },
               "shape": [
                 3,
-                915,
-                915
+                90,
+                90
               ],
               "data_type": "uint8",
               "chunk_grid": {
@@ -1233,8 +1320,8 @@
                 "configuration": {
                   "chunk_shape": [
                     1,
-                    915,
-                    915
+                    90,
+                    90
                   ]
                 }
               },
@@ -1251,21 +1338,21 @@
                   "configuration": {
                     "chunk_shape": [
                       1,
-                      305,
-                      305
+                      90,
+                      90
                     ],
                     "codecs": [
                       {
-                        "name": "bytes",
-                        "configuration": {
-                          "endian": "little"
-                        }
+                        "name": "bytes"
                       },
                       {
                         "name": "blosc",
                         "configuration": {
+                          "typesize": 1,
                           "cname": "zstd",
-                          "clevel": 5
+                          "clevel": 5,
+                          "shuffle": "bitshuffle",
+                          "blocksize": 0
                         }
                       }
                     ],
@@ -1290,15 +1377,872 @@
                 "y",
                 "x"
               ]
+            },
+            "spatial_ref": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "crs_wkt": "PROJCRS[\"WGS 84 / UTM zone 31N\",BASEGEOGCRS[\"WGS 84\",ENSEMBLE[\"World Geodetic System 1984 ensemble\",MEMBER[\"World Geodetic System 1984 (Transit)\"],MEMBER[\"World Geodetic System 1984 (G730)\"],MEMBER[\"World Geodetic System 1984 (G873)\"],MEMBER[\"World Geodetic System 1984 (G1150)\"],MEMBER[\"World Geodetic System 1984 (G1674)\"],MEMBER[\"World Geodetic System 1984 (G1762)\"],MEMBER[\"World Geodetic System 1984 (G2139)\"],MEMBER[\"World Geodetic System 1984 (G2296)\"],ELLIPSOID[\"WGS 84\",6378137,298.257223563,LENGTHUNIT[\"metre\",1]],ENSEMBLEACCURACY[2.0]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433]],ID[\"EPSG\",4326]],CONVERSION[\"UTM zone 31N\",METHOD[\"Transverse Mercator\",ID[\"EPSG\",9807]],PARAMETER[\"Latitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8801]],PARAMETER[\"Longitude of natural origin\",3,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"Scale factor at natural origin\",0.9996,SCALEUNIT[\"unity\",1],ID[\"EPSG\",8805]],PARAMETER[\"False easting\",500000,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"(E)\",east,ORDER[1],LENGTHUNIT[\"metre\",1]],AXIS[\"(N)\",north,ORDER[2],LENGTHUNIT[\"metre\",1]],USAGE[SCOPE[\"Navigation and medium accuracy spatial referencing.\"],AREA[\"Between 0\u00b0E and 6\u00b0E, northern hemisphere between equator and 84\u00b0N, onshore and offshore. Algeria. Andorra. Belgium. Benin. Burkina Faso. Denmark - North Sea. France. Germany - North Sea. Ghana. Luxembourg. Mali. Netherlands. Niger. Nigeria. Norway. Spain. Togo. United Kingdom (UK) - North Sea.\"],BBOX[0,0,84,6]],ID[\"EPSG\",32631]]",
+                "semi_major_axis": 6378137.0,
+                "semi_minor_axis": 6356752.314245179,
+                "inverse_flattening": 298.257223563,
+                "reference_ellipsoid_name": "WGS 84",
+                "longitude_of_prime_meridian": 0.0,
+                "prime_meridian_name": "Greenwich",
+                "geographic_crs_name": "WGS 84",
+                "horizontal_datum_name": "World Geodetic System 1984 ensemble",
+                "projected_crs_name": "WGS 84 / UTM zone 31N",
+                "grid_mapping_name": "transverse_mercator",
+                "latitude_of_projection_origin": 0.0,
+                "longitude_of_central_meridian": 3.0,
+                "false_easting": 500000.0,
+                "false_northing": 0.0,
+                "scale_factor_at_central_meridian": 0.9996,
+                "spatial_ref": "PROJCRS[\"WGS 84 / UTM zone 31N\",BASEGEOGCRS[\"WGS 84\",ENSEMBLE[\"World Geodetic System 1984 ensemble\",MEMBER[\"World Geodetic System 1984 (Transit)\"],MEMBER[\"World Geodetic System 1984 (G730)\"],MEMBER[\"World Geodetic System 1984 (G873)\"],MEMBER[\"World Geodetic System 1984 (G1150)\"],MEMBER[\"World Geodetic System 1984 (G1674)\"],MEMBER[\"World Geodetic System 1984 (G1762)\"],MEMBER[\"World Geodetic System 1984 (G2139)\"],MEMBER[\"World Geodetic System 1984 (G2296)\"],ELLIPSOID[\"WGS 84\",6378137,298.257223563,LENGTHUNIT[\"metre\",1]],ENSEMBLEACCURACY[2.0]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433]],ID[\"EPSG\",4326]],CONVERSION[\"UTM zone 31N\",METHOD[\"Transverse Mercator\",ID[\"EPSG\",9807]],PARAMETER[\"Latitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8801]],PARAMETER[\"Longitude of natural origin\",3,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"Scale factor at natural origin\",0.9996,SCALEUNIT[\"unity\",1],ID[\"EPSG\",8805]],PARAMETER[\"False easting\",500000,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"(E)\",east,ORDER[1],LENGTHUNIT[\"metre\",1]],AXIS[\"(N)\",north,ORDER[2],LENGTHUNIT[\"metre\",1]],USAGE[SCOPE[\"Navigation and medium accuracy spatial referencing.\"],AREA[\"Between 0\u00b0E and 6\u00b0E, northern hemisphere between equator and 84\u00b0N, onshore and offshore. Algeria. Andorra. Belgium. Benin. Burkina Faso. Denmark - North Sea. France. Germany - North Sea. Ghana. Luxembourg. Mali. Netherlands. Niger. Nigeria. Norway. Spain. Togo. United Kingdom (UK) - North Sea.\"],BBOX[0,0,84,6]],ID[\"EPSG\",32631]]",
+                "_ARRAY_DIMENSIONS": []
+              },
+              "shape": [],
+              "data_type": "int64",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": []
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": 0,
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "zstd",
+                  "configuration": {
+                    "level": 0,
+                    "checksum": false
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": null
+            },
+            "time": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "units": "nanoseconds since 1970-01-01",
+                "calendar": "proleptic_gregorian",
+                "standard_name": "time",
+                "_ARRAY_DIMENSIONS": [
+                  "time"
+                ]
+              },
+              "shape": [
+                3
+              ],
+              "data_type": "int64",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": [
+                    512
+                  ]
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": 0,
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "zstd",
+                  "configuration": {
+                    "level": 0,
+                    "checksum": false
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": [
+                "time"
+              ]
+            },
+            "vh": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "standard_name": "surface_backwards_scattering_coefficient_of_radar_wave",
+                "units": "1",
+                "_FillValue": "AAAAAAAA+H8=",
+                "grid_mapping": "spatial_ref"
+              },
+              "shape": [
+                3,
+                90,
+                90
+              ],
+              "data_type": "float32",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": [
+                    1,
+                    90,
+                    90
+                  ]
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": "NaN",
+              "codecs": [
+                {
+                  "name": "sharding_indexed",
+                  "configuration": {
+                    "chunk_shape": [
+                      1,
+                      90,
+                      90
+                    ],
+                    "codecs": [
+                      {
+                        "name": "bytes",
+                        "configuration": {
+                          "endian": "little"
+                        }
+                      },
+                      {
+                        "name": "blosc",
+                        "configuration": {
+                          "typesize": 4,
+                          "cname": "zstd",
+                          "clevel": 5,
+                          "shuffle": "shuffle",
+                          "blocksize": 0
+                        }
+                      }
+                    ],
+                    "index_codecs": [
+                      {
+                        "name": "bytes",
+                        "configuration": {
+                          "endian": "little"
+                        }
+                      },
+                      {
+                        "name": "crc32c"
+                      }
+                    ],
+                    "index_location": "end"
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": [
+                "time",
+                "y",
+                "x"
+              ]
+            },
+            "vv": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "standard_name": "surface_backwards_scattering_coefficient_of_radar_wave",
+                "units": "1",
+                "_FillValue": "AAAAAAAA+H8=",
+                "grid_mapping": "spatial_ref"
+              },
+              "shape": [
+                3,
+                90,
+                90
+              ],
+              "data_type": "float32",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": [
+                    1,
+                    90,
+                    90
+                  ]
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": "NaN",
+              "codecs": [
+                {
+                  "name": "sharding_indexed",
+                  "configuration": {
+                    "chunk_shape": [
+                      1,
+                      90,
+                      90
+                    ],
+                    "codecs": [
+                      {
+                        "name": "bytes",
+                        "configuration": {
+                          "endian": "little"
+                        }
+                      },
+                      {
+                        "name": "blosc",
+                        "configuration": {
+                          "typesize": 4,
+                          "cname": "zstd",
+                          "clevel": 5,
+                          "shuffle": "shuffle",
+                          "blocksize": 0
+                        }
+                      }
+                    ],
+                    "index_codecs": [
+                      {
+                        "name": "bytes",
+                        "configuration": {
+                          "endian": "little"
+                        }
+                      },
+                      {
+                        "name": "crc32c"
+                      }
+                    ],
+                    "index_location": "end"
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": [
+                "time",
+                "y",
+                "x"
+              ]
+            },
+            "x": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "units": "m",
+                "long_name": "x coordinate of projection",
+                "standard_name": "projection_x_coordinate",
+                "_ARRAY_DIMENSIONS": [
+                  "x"
+                ]
+              },
+              "shape": [
+                90
+              ],
+              "data_type": "float64",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": [
+                    90
+                  ]
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": "NaN",
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "zstd",
+                  "configuration": {
+                    "level": 0,
+                    "checksum": false
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": [
+                "x"
+              ]
+            },
+            "y": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "units": "m",
+                "long_name": "y coordinate of projection",
+                "standard_name": "projection_y_coordinate",
+                "_ARRAY_DIMENSIONS": [
+                  "y"
+                ]
+              },
+              "shape": [
+                90
+              ],
+              "data_type": "float64",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": [
+                    90
+                  ]
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": "NaN",
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "zstd",
+                  "configuration": {
+                    "level": 0,
+                    "checksum": false
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": [
+                "y"
+              ]
+            }
+          }
+        },
+        "r20m": {
+          "zarr_format": 3,
+          "node_type": "group",
+          "attributes": {
+            "spatial:dimensions": [
+              "y",
+              "x"
+            ],
+            "spatial:shape": [
+              540,
+              540
+            ],
+            "spatial:transform": [
+              20.0,
+              0.0,
+              500000.0,
+              0.0,
+              -20.0,
+              5000000.0
+            ],
+            "zarr_conventions": [
+              {
+                "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                "name": "spatial:",
+                "description": "Spatial coordinate information"
+              },
+              {
+                "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                "name": "proj:",
+                "description": "Coordinate reference system information for geospatial data"
+              }
+            ],
+            "proj:code": "EPSG:32631"
+          },
+          "members": {
+            "border_mask": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "grid_mapping": "spatial_ref"
+              },
+              "shape": [
+                3,
+                540,
+                540
+              ],
+              "data_type": "uint8",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": [
+                    1,
+                    540,
+                    540
+                  ]
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": 0,
+              "codecs": [
+                {
+                  "name": "sharding_indexed",
+                  "configuration": {
+                    "chunk_shape": [
+                      1,
+                      270,
+                      270
+                    ],
+                    "codecs": [
+                      {
+                        "name": "bytes"
+                      },
+                      {
+                        "name": "blosc",
+                        "configuration": {
+                          "typesize": 1,
+                          "cname": "zstd",
+                          "clevel": 5,
+                          "shuffle": "bitshuffle",
+                          "blocksize": 0
+                        }
+                      }
+                    ],
+                    "index_codecs": [
+                      {
+                        "name": "bytes",
+                        "configuration": {
+                          "endian": "little"
+                        }
+                      },
+                      {
+                        "name": "crc32c"
+                      }
+                    ],
+                    "index_location": "end"
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": [
+                "time",
+                "y",
+                "x"
+              ]
+            },
+            "spatial_ref": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "crs_wkt": "PROJCRS[\"WGS 84 / UTM zone 31N\",BASEGEOGCRS[\"WGS 84\",ENSEMBLE[\"World Geodetic System 1984 ensemble\",MEMBER[\"World Geodetic System 1984 (Transit)\"],MEMBER[\"World Geodetic System 1984 (G730)\"],MEMBER[\"World Geodetic System 1984 (G873)\"],MEMBER[\"World Geodetic System 1984 (G1150)\"],MEMBER[\"World Geodetic System 1984 (G1674)\"],MEMBER[\"World Geodetic System 1984 (G1762)\"],MEMBER[\"World Geodetic System 1984 (G2139)\"],MEMBER[\"World Geodetic System 1984 (G2296)\"],ELLIPSOID[\"WGS 84\",6378137,298.257223563,LENGTHUNIT[\"metre\",1]],ENSEMBLEACCURACY[2.0]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433]],ID[\"EPSG\",4326]],CONVERSION[\"UTM zone 31N\",METHOD[\"Transverse Mercator\",ID[\"EPSG\",9807]],PARAMETER[\"Latitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8801]],PARAMETER[\"Longitude of natural origin\",3,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"Scale factor at natural origin\",0.9996,SCALEUNIT[\"unity\",1],ID[\"EPSG\",8805]],PARAMETER[\"False easting\",500000,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"(E)\",east,ORDER[1],LENGTHUNIT[\"metre\",1]],AXIS[\"(N)\",north,ORDER[2],LENGTHUNIT[\"metre\",1]],USAGE[SCOPE[\"Navigation and medium accuracy spatial referencing.\"],AREA[\"Between 0\u00b0E and 6\u00b0E, northern hemisphere between equator and 84\u00b0N, onshore and offshore. Algeria. Andorra. Belgium. Benin. Burkina Faso. Denmark - North Sea. France. Germany - North Sea. Ghana. Luxembourg. Mali. Netherlands. Niger. Nigeria. Norway. Spain. Togo. United Kingdom (UK) - North Sea.\"],BBOX[0,0,84,6]],ID[\"EPSG\",32631]]",
+                "semi_major_axis": 6378137.0,
+                "semi_minor_axis": 6356752.314245179,
+                "inverse_flattening": 298.257223563,
+                "reference_ellipsoid_name": "WGS 84",
+                "longitude_of_prime_meridian": 0.0,
+                "prime_meridian_name": "Greenwich",
+                "geographic_crs_name": "WGS 84",
+                "horizontal_datum_name": "World Geodetic System 1984 ensemble",
+                "projected_crs_name": "WGS 84 / UTM zone 31N",
+                "grid_mapping_name": "transverse_mercator",
+                "latitude_of_projection_origin": 0.0,
+                "longitude_of_central_meridian": 3.0,
+                "false_easting": 500000.0,
+                "false_northing": 0.0,
+                "scale_factor_at_central_meridian": 0.9996,
+                "spatial_ref": "PROJCRS[\"WGS 84 / UTM zone 31N\",BASEGEOGCRS[\"WGS 84\",ENSEMBLE[\"World Geodetic System 1984 ensemble\",MEMBER[\"World Geodetic System 1984 (Transit)\"],MEMBER[\"World Geodetic System 1984 (G730)\"],MEMBER[\"World Geodetic System 1984 (G873)\"],MEMBER[\"World Geodetic System 1984 (G1150)\"],MEMBER[\"World Geodetic System 1984 (G1674)\"],MEMBER[\"World Geodetic System 1984 (G1762)\"],MEMBER[\"World Geodetic System 1984 (G2139)\"],MEMBER[\"World Geodetic System 1984 (G2296)\"],ELLIPSOID[\"WGS 84\",6378137,298.257223563,LENGTHUNIT[\"metre\",1]],ENSEMBLEACCURACY[2.0]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433]],ID[\"EPSG\",4326]],CONVERSION[\"UTM zone 31N\",METHOD[\"Transverse Mercator\",ID[\"EPSG\",9807]],PARAMETER[\"Latitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8801]],PARAMETER[\"Longitude of natural origin\",3,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"Scale factor at natural origin\",0.9996,SCALEUNIT[\"unity\",1],ID[\"EPSG\",8805]],PARAMETER[\"False easting\",500000,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"(E)\",east,ORDER[1],LENGTHUNIT[\"metre\",1]],AXIS[\"(N)\",north,ORDER[2],LENGTHUNIT[\"metre\",1]],USAGE[SCOPE[\"Navigation and medium accuracy spatial referencing.\"],AREA[\"Between 0\u00b0E and 6\u00b0E, northern hemisphere between equator and 84\u00b0N, onshore and offshore. Algeria. Andorra. Belgium. Benin. Burkina Faso. Denmark - North Sea. France. Germany - North Sea. Ghana. Luxembourg. Mali. Netherlands. Niger. Nigeria. Norway. Spain. Togo. United Kingdom (UK) - North Sea.\"],BBOX[0,0,84,6]],ID[\"EPSG\",32631]]",
+                "_ARRAY_DIMENSIONS": []
+              },
+              "shape": [],
+              "data_type": "int64",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": []
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": 0,
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "zstd",
+                  "configuration": {
+                    "level": 0,
+                    "checksum": false
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": null
+            },
+            "time": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "units": "nanoseconds since 1970-01-01",
+                "calendar": "proleptic_gregorian",
+                "standard_name": "time",
+                "_ARRAY_DIMENSIONS": [
+                  "time"
+                ]
+              },
+              "shape": [
+                3
+              ],
+              "data_type": "int64",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": [
+                    512
+                  ]
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": 0,
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "zstd",
+                  "configuration": {
+                    "level": 0,
+                    "checksum": false
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": [
+                "time"
+              ]
+            },
+            "vh": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "standard_name": "surface_backwards_scattering_coefficient_of_radar_wave",
+                "units": "1",
+                "_FillValue": "AAAAAAAA+H8=",
+                "grid_mapping": "spatial_ref"
+              },
+              "shape": [
+                3,
+                540,
+                540
+              ],
+              "data_type": "float32",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": [
+                    1,
+                    540,
+                    540
+                  ]
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": "NaN",
+              "codecs": [
+                {
+                  "name": "sharding_indexed",
+                  "configuration": {
+                    "chunk_shape": [
+                      1,
+                      270,
+                      270
+                    ],
+                    "codecs": [
+                      {
+                        "name": "bytes",
+                        "configuration": {
+                          "endian": "little"
+                        }
+                      },
+                      {
+                        "name": "blosc",
+                        "configuration": {
+                          "typesize": 4,
+                          "cname": "zstd",
+                          "clevel": 5,
+                          "shuffle": "shuffle",
+                          "blocksize": 0
+                        }
+                      }
+                    ],
+                    "index_codecs": [
+                      {
+                        "name": "bytes",
+                        "configuration": {
+                          "endian": "little"
+                        }
+                      },
+                      {
+                        "name": "crc32c"
+                      }
+                    ],
+                    "index_location": "end"
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": [
+                "time",
+                "y",
+                "x"
+              ]
+            },
+            "vv": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "standard_name": "surface_backwards_scattering_coefficient_of_radar_wave",
+                "units": "1",
+                "_FillValue": "AAAAAAAA+H8=",
+                "grid_mapping": "spatial_ref"
+              },
+              "shape": [
+                3,
+                540,
+                540
+              ],
+              "data_type": "float32",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": [
+                    1,
+                    540,
+                    540
+                  ]
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": "NaN",
+              "codecs": [
+                {
+                  "name": "sharding_indexed",
+                  "configuration": {
+                    "chunk_shape": [
+                      1,
+                      270,
+                      270
+                    ],
+                    "codecs": [
+                      {
+                        "name": "bytes",
+                        "configuration": {
+                          "endian": "little"
+                        }
+                      },
+                      {
+                        "name": "blosc",
+                        "configuration": {
+                          "typesize": 4,
+                          "cname": "zstd",
+                          "clevel": 5,
+                          "shuffle": "shuffle",
+                          "blocksize": 0
+                        }
+                      }
+                    ],
+                    "index_codecs": [
+                      {
+                        "name": "bytes",
+                        "configuration": {
+                          "endian": "little"
+                        }
+                      },
+                      {
+                        "name": "crc32c"
+                      }
+                    ],
+                    "index_location": "end"
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": [
+                "time",
+                "y",
+                "x"
+              ]
+            },
+            "x": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "units": "m",
+                "long_name": "x coordinate of projection",
+                "standard_name": "projection_x_coordinate",
+                "_ARRAY_DIMENSIONS": [
+                  "x"
+                ]
+              },
+              "shape": [
+                540
+              ],
+              "data_type": "float64",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": [
+                    540
+                  ]
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": "NaN",
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "zstd",
+                  "configuration": {
+                    "level": 0,
+                    "checksum": false
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": [
+                "x"
+              ]
+            },
+            "y": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "units": "m",
+                "long_name": "y coordinate of projection",
+                "standard_name": "projection_y_coordinate",
+                "_ARRAY_DIMENSIONS": [
+                  "y"
+                ]
+              },
+              "shape": [
+                540
+              ],
+              "data_type": "float64",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": [
+                    540
+                  ]
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": "NaN",
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "zstd",
+                  "configuration": {
+                    "level": 0,
+                    "checksum": false
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": [
+                "y"
+              ]
             }
           }
         },
         "r360m": {
           "zarr_format": 3,
+          "node_type": "group",
           "attributes": {
+            "spatial:dimensions": [
+              "y",
+              "x"
+            ],
             "spatial:shape": [
-              305,
-              305
+              30,
+              30
             ],
             "spatial:transform": [
               360.0,
@@ -1307,163 +2251,36 @@
               0.0,
               -360.0,
               5000000.0
-            ]
+            ],
+            "zarr_conventions": [
+              {
+                "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                "name": "spatial:",
+                "description": "Spatial coordinate information"
+              },
+              {
+                "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                "name": "proj:",
+                "description": "Coordinate reference system information for geospatial data"
+              }
+            ],
+            "proj:code": "EPSG:32631"
           },
           "members": {
-            "vv": {
-              "zarr_format": 3,
-              "node_type": "array",
-              "attributes": {},
-              "shape": [
-                3,
-                305,
-                305
-              ],
-              "data_type": "float32",
-              "chunk_grid": {
-                "name": "regular",
-                "configuration": {
-                  "chunk_shape": [
-                    1,
-                    305,
-                    305
-                  ]
-                }
-              },
-              "chunk_key_encoding": {
-                "name": "default",
-                "configuration": {
-                  "separator": "/"
-                }
-              },
-              "fill_value": "NaN",
-              "codecs": [
-                {
-                  "name": "sharding_indexed",
-                  "configuration": {
-                    "chunk_shape": [
-                      1,
-                      305,
-                      305
-                    ],
-                    "codecs": [
-                      {
-                        "name": "bytes",
-                        "configuration": {
-                          "endian": "little"
-                        }
-                      },
-                      {
-                        "name": "blosc",
-                        "configuration": {
-                          "cname": "zstd",
-                          "clevel": 5
-                        }
-                      }
-                    ],
-                    "index_codecs": [
-                      {
-                        "name": "bytes",
-                        "configuration": {
-                          "endian": "little"
-                        }
-                      },
-                      {
-                        "name": "crc32c"
-                      }
-                    ],
-                    "index_location": "end"
-                  }
-                }
-              ],
-              "storage_transformers": [],
-              "dimension_names": [
-                "time",
-                "y",
-                "x"
-              ]
-            },
-            "vh": {
-              "zarr_format": 3,
-              "node_type": "array",
-              "attributes": {},
-              "shape": [
-                3,
-                305,
-                305
-              ],
-              "data_type": "float32",
-              "chunk_grid": {
-                "name": "regular",
-                "configuration": {
-                  "chunk_shape": [
-                    1,
-                    305,
-                    305
-                  ]
-                }
-              },
-              "chunk_key_encoding": {
-                "name": "default",
-                "configuration": {
-                  "separator": "/"
-                }
-              },
-              "fill_value": "NaN",
-              "codecs": [
-                {
-                  "name": "sharding_indexed",
-                  "configuration": {
-                    "chunk_shape": [
-                      1,
-                      305,
-                      305
-                    ],
-                    "codecs": [
-                      {
-                        "name": "bytes",
-                        "configuration": {
-                          "endian": "little"
-                        }
-                      },
-                      {
-                        "name": "blosc",
-                        "configuration": {
-                          "cname": "zstd",
-                          "clevel": 5
-                        }
-                      }
-                    ],
-                    "index_codecs": [
-                      {
-                        "name": "bytes",
-                        "configuration": {
-                          "endian": "little"
-                        }
-                      },
-                      {
-                        "name": "crc32c"
-                      }
-                    ],
-                    "index_location": "end"
-                  }
-                }
-              ],
-              "storage_transformers": [],
-              "dimension_names": [
-                "time",
-                "y",
-                "x"
-              ]
-            },
             "border_mask": {
               "zarr_format": 3,
               "node_type": "array",
-              "attributes": {},
+              "attributes": {
+                "grid_mapping": "spatial_ref"
+              },
               "shape": [
                 3,
-                305,
-                305
+                30,
+                30
               ],
               "data_type": "uint8",
               "chunk_grid": {
@@ -1471,8 +2288,8 @@
                 "configuration": {
                   "chunk_shape": [
                     1,
-                    305,
-                    305
+                    30,
+                    30
                   ]
                 }
               },
@@ -1489,21 +2306,21 @@
                   "configuration": {
                     "chunk_shape": [
                       1,
-                      305,
-                      305
+                      30,
+                      30
                     ],
                     "codecs": [
                       {
-                        "name": "bytes",
-                        "configuration": {
-                          "endian": "little"
-                        }
+                        "name": "bytes"
                       },
                       {
                         "name": "blosc",
                         "configuration": {
+                          "typesize": 1,
                           "cname": "zstd",
-                          "clevel": 5
+                          "clevel": 5,
+                          "shuffle": "bitshuffle",
+                          "blocksize": 0
                         }
                       }
                     ],
@@ -1528,15 +2345,872 @@
                 "y",
                 "x"
               ]
+            },
+            "spatial_ref": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "crs_wkt": "PROJCRS[\"WGS 84 / UTM zone 31N\",BASEGEOGCRS[\"WGS 84\",ENSEMBLE[\"World Geodetic System 1984 ensemble\",MEMBER[\"World Geodetic System 1984 (Transit)\"],MEMBER[\"World Geodetic System 1984 (G730)\"],MEMBER[\"World Geodetic System 1984 (G873)\"],MEMBER[\"World Geodetic System 1984 (G1150)\"],MEMBER[\"World Geodetic System 1984 (G1674)\"],MEMBER[\"World Geodetic System 1984 (G1762)\"],MEMBER[\"World Geodetic System 1984 (G2139)\"],MEMBER[\"World Geodetic System 1984 (G2296)\"],ELLIPSOID[\"WGS 84\",6378137,298.257223563,LENGTHUNIT[\"metre\",1]],ENSEMBLEACCURACY[2.0]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433]],ID[\"EPSG\",4326]],CONVERSION[\"UTM zone 31N\",METHOD[\"Transverse Mercator\",ID[\"EPSG\",9807]],PARAMETER[\"Latitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8801]],PARAMETER[\"Longitude of natural origin\",3,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"Scale factor at natural origin\",0.9996,SCALEUNIT[\"unity\",1],ID[\"EPSG\",8805]],PARAMETER[\"False easting\",500000,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"(E)\",east,ORDER[1],LENGTHUNIT[\"metre\",1]],AXIS[\"(N)\",north,ORDER[2],LENGTHUNIT[\"metre\",1]],USAGE[SCOPE[\"Navigation and medium accuracy spatial referencing.\"],AREA[\"Between 0\u00b0E and 6\u00b0E, northern hemisphere between equator and 84\u00b0N, onshore and offshore. Algeria. Andorra. Belgium. Benin. Burkina Faso. Denmark - North Sea. France. Germany - North Sea. Ghana. Luxembourg. Mali. Netherlands. Niger. Nigeria. Norway. Spain. Togo. United Kingdom (UK) - North Sea.\"],BBOX[0,0,84,6]],ID[\"EPSG\",32631]]",
+                "semi_major_axis": 6378137.0,
+                "semi_minor_axis": 6356752.314245179,
+                "inverse_flattening": 298.257223563,
+                "reference_ellipsoid_name": "WGS 84",
+                "longitude_of_prime_meridian": 0.0,
+                "prime_meridian_name": "Greenwich",
+                "geographic_crs_name": "WGS 84",
+                "horizontal_datum_name": "World Geodetic System 1984 ensemble",
+                "projected_crs_name": "WGS 84 / UTM zone 31N",
+                "grid_mapping_name": "transverse_mercator",
+                "latitude_of_projection_origin": 0.0,
+                "longitude_of_central_meridian": 3.0,
+                "false_easting": 500000.0,
+                "false_northing": 0.0,
+                "scale_factor_at_central_meridian": 0.9996,
+                "spatial_ref": "PROJCRS[\"WGS 84 / UTM zone 31N\",BASEGEOGCRS[\"WGS 84\",ENSEMBLE[\"World Geodetic System 1984 ensemble\",MEMBER[\"World Geodetic System 1984 (Transit)\"],MEMBER[\"World Geodetic System 1984 (G730)\"],MEMBER[\"World Geodetic System 1984 (G873)\"],MEMBER[\"World Geodetic System 1984 (G1150)\"],MEMBER[\"World Geodetic System 1984 (G1674)\"],MEMBER[\"World Geodetic System 1984 (G1762)\"],MEMBER[\"World Geodetic System 1984 (G2139)\"],MEMBER[\"World Geodetic System 1984 (G2296)\"],ELLIPSOID[\"WGS 84\",6378137,298.257223563,LENGTHUNIT[\"metre\",1]],ENSEMBLEACCURACY[2.0]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433]],ID[\"EPSG\",4326]],CONVERSION[\"UTM zone 31N\",METHOD[\"Transverse Mercator\",ID[\"EPSG\",9807]],PARAMETER[\"Latitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8801]],PARAMETER[\"Longitude of natural origin\",3,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"Scale factor at natural origin\",0.9996,SCALEUNIT[\"unity\",1],ID[\"EPSG\",8805]],PARAMETER[\"False easting\",500000,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"(E)\",east,ORDER[1],LENGTHUNIT[\"metre\",1]],AXIS[\"(N)\",north,ORDER[2],LENGTHUNIT[\"metre\",1]],USAGE[SCOPE[\"Navigation and medium accuracy spatial referencing.\"],AREA[\"Between 0\u00b0E and 6\u00b0E, northern hemisphere between equator and 84\u00b0N, onshore and offshore. Algeria. Andorra. Belgium. Benin. Burkina Faso. Denmark - North Sea. France. Germany - North Sea. Ghana. Luxembourg. Mali. Netherlands. Niger. Nigeria. Norway. Spain. Togo. United Kingdom (UK) - North Sea.\"],BBOX[0,0,84,6]],ID[\"EPSG\",32631]]",
+                "_ARRAY_DIMENSIONS": []
+              },
+              "shape": [],
+              "data_type": "int64",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": []
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": 0,
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "zstd",
+                  "configuration": {
+                    "level": 0,
+                    "checksum": false
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": null
+            },
+            "time": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "units": "nanoseconds since 1970-01-01",
+                "calendar": "proleptic_gregorian",
+                "standard_name": "time",
+                "_ARRAY_DIMENSIONS": [
+                  "time"
+                ]
+              },
+              "shape": [
+                3
+              ],
+              "data_type": "int64",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": [
+                    512
+                  ]
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": 0,
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "zstd",
+                  "configuration": {
+                    "level": 0,
+                    "checksum": false
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": [
+                "time"
+              ]
+            },
+            "vh": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "standard_name": "surface_backwards_scattering_coefficient_of_radar_wave",
+                "units": "1",
+                "_FillValue": "AAAAAAAA+H8=",
+                "grid_mapping": "spatial_ref"
+              },
+              "shape": [
+                3,
+                30,
+                30
+              ],
+              "data_type": "float32",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": [
+                    1,
+                    30,
+                    30
+                  ]
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": "NaN",
+              "codecs": [
+                {
+                  "name": "sharding_indexed",
+                  "configuration": {
+                    "chunk_shape": [
+                      1,
+                      30,
+                      30
+                    ],
+                    "codecs": [
+                      {
+                        "name": "bytes",
+                        "configuration": {
+                          "endian": "little"
+                        }
+                      },
+                      {
+                        "name": "blosc",
+                        "configuration": {
+                          "typesize": 4,
+                          "cname": "zstd",
+                          "clevel": 5,
+                          "shuffle": "shuffle",
+                          "blocksize": 0
+                        }
+                      }
+                    ],
+                    "index_codecs": [
+                      {
+                        "name": "bytes",
+                        "configuration": {
+                          "endian": "little"
+                        }
+                      },
+                      {
+                        "name": "crc32c"
+                      }
+                    ],
+                    "index_location": "end"
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": [
+                "time",
+                "y",
+                "x"
+              ]
+            },
+            "vv": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "standard_name": "surface_backwards_scattering_coefficient_of_radar_wave",
+                "units": "1",
+                "_FillValue": "AAAAAAAA+H8=",
+                "grid_mapping": "spatial_ref"
+              },
+              "shape": [
+                3,
+                30,
+                30
+              ],
+              "data_type": "float32",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": [
+                    1,
+                    30,
+                    30
+                  ]
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": "NaN",
+              "codecs": [
+                {
+                  "name": "sharding_indexed",
+                  "configuration": {
+                    "chunk_shape": [
+                      1,
+                      30,
+                      30
+                    ],
+                    "codecs": [
+                      {
+                        "name": "bytes",
+                        "configuration": {
+                          "endian": "little"
+                        }
+                      },
+                      {
+                        "name": "blosc",
+                        "configuration": {
+                          "typesize": 4,
+                          "cname": "zstd",
+                          "clevel": 5,
+                          "shuffle": "shuffle",
+                          "blocksize": 0
+                        }
+                      }
+                    ],
+                    "index_codecs": [
+                      {
+                        "name": "bytes",
+                        "configuration": {
+                          "endian": "little"
+                        }
+                      },
+                      {
+                        "name": "crc32c"
+                      }
+                    ],
+                    "index_location": "end"
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": [
+                "time",
+                "y",
+                "x"
+              ]
+            },
+            "x": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "units": "m",
+                "long_name": "x coordinate of projection",
+                "standard_name": "projection_x_coordinate",
+                "_ARRAY_DIMENSIONS": [
+                  "x"
+                ]
+              },
+              "shape": [
+                30
+              ],
+              "data_type": "float64",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": [
+                    30
+                  ]
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": "NaN",
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "zstd",
+                  "configuration": {
+                    "level": 0,
+                    "checksum": false
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": [
+                "x"
+              ]
+            },
+            "y": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "units": "m",
+                "long_name": "y coordinate of projection",
+                "standard_name": "projection_y_coordinate",
+                "_ARRAY_DIMENSIONS": [
+                  "y"
+                ]
+              },
+              "shape": [
+                30
+              ],
+              "data_type": "float64",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": [
+                    30
+                  ]
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": "NaN",
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "zstd",
+                  "configuration": {
+                    "level": 0,
+                    "checksum": false
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": [
+                "y"
+              ]
+            }
+          }
+        },
+        "r60m": {
+          "zarr_format": 3,
+          "node_type": "group",
+          "attributes": {
+            "spatial:dimensions": [
+              "y",
+              "x"
+            ],
+            "spatial:shape": [
+              180,
+              180
+            ],
+            "spatial:transform": [
+              60.0,
+              0.0,
+              500000.0,
+              0.0,
+              -60.0,
+              5000000.0
+            ],
+            "zarr_conventions": [
+              {
+                "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                "name": "spatial:",
+                "description": "Spatial coordinate information"
+              },
+              {
+                "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                "name": "proj:",
+                "description": "Coordinate reference system information for geospatial data"
+              }
+            ],
+            "proj:code": "EPSG:32631"
+          },
+          "members": {
+            "border_mask": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "grid_mapping": "spatial_ref"
+              },
+              "shape": [
+                3,
+                180,
+                180
+              ],
+              "data_type": "uint8",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": [
+                    1,
+                    180,
+                    180
+                  ]
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": 0,
+              "codecs": [
+                {
+                  "name": "sharding_indexed",
+                  "configuration": {
+                    "chunk_shape": [
+                      1,
+                      180,
+                      180
+                    ],
+                    "codecs": [
+                      {
+                        "name": "bytes"
+                      },
+                      {
+                        "name": "blosc",
+                        "configuration": {
+                          "typesize": 1,
+                          "cname": "zstd",
+                          "clevel": 5,
+                          "shuffle": "bitshuffle",
+                          "blocksize": 0
+                        }
+                      }
+                    ],
+                    "index_codecs": [
+                      {
+                        "name": "bytes",
+                        "configuration": {
+                          "endian": "little"
+                        }
+                      },
+                      {
+                        "name": "crc32c"
+                      }
+                    ],
+                    "index_location": "end"
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": [
+                "time",
+                "y",
+                "x"
+              ]
+            },
+            "spatial_ref": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "crs_wkt": "PROJCRS[\"WGS 84 / UTM zone 31N\",BASEGEOGCRS[\"WGS 84\",ENSEMBLE[\"World Geodetic System 1984 ensemble\",MEMBER[\"World Geodetic System 1984 (Transit)\"],MEMBER[\"World Geodetic System 1984 (G730)\"],MEMBER[\"World Geodetic System 1984 (G873)\"],MEMBER[\"World Geodetic System 1984 (G1150)\"],MEMBER[\"World Geodetic System 1984 (G1674)\"],MEMBER[\"World Geodetic System 1984 (G1762)\"],MEMBER[\"World Geodetic System 1984 (G2139)\"],MEMBER[\"World Geodetic System 1984 (G2296)\"],ELLIPSOID[\"WGS 84\",6378137,298.257223563,LENGTHUNIT[\"metre\",1]],ENSEMBLEACCURACY[2.0]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433]],ID[\"EPSG\",4326]],CONVERSION[\"UTM zone 31N\",METHOD[\"Transverse Mercator\",ID[\"EPSG\",9807]],PARAMETER[\"Latitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8801]],PARAMETER[\"Longitude of natural origin\",3,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"Scale factor at natural origin\",0.9996,SCALEUNIT[\"unity\",1],ID[\"EPSG\",8805]],PARAMETER[\"False easting\",500000,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"(E)\",east,ORDER[1],LENGTHUNIT[\"metre\",1]],AXIS[\"(N)\",north,ORDER[2],LENGTHUNIT[\"metre\",1]],USAGE[SCOPE[\"Navigation and medium accuracy spatial referencing.\"],AREA[\"Between 0\u00b0E and 6\u00b0E, northern hemisphere between equator and 84\u00b0N, onshore and offshore. Algeria. Andorra. Belgium. Benin. Burkina Faso. Denmark - North Sea. France. Germany - North Sea. Ghana. Luxembourg. Mali. Netherlands. Niger. Nigeria. Norway. Spain. Togo. United Kingdom (UK) - North Sea.\"],BBOX[0,0,84,6]],ID[\"EPSG\",32631]]",
+                "semi_major_axis": 6378137.0,
+                "semi_minor_axis": 6356752.314245179,
+                "inverse_flattening": 298.257223563,
+                "reference_ellipsoid_name": "WGS 84",
+                "longitude_of_prime_meridian": 0.0,
+                "prime_meridian_name": "Greenwich",
+                "geographic_crs_name": "WGS 84",
+                "horizontal_datum_name": "World Geodetic System 1984 ensemble",
+                "projected_crs_name": "WGS 84 / UTM zone 31N",
+                "grid_mapping_name": "transverse_mercator",
+                "latitude_of_projection_origin": 0.0,
+                "longitude_of_central_meridian": 3.0,
+                "false_easting": 500000.0,
+                "false_northing": 0.0,
+                "scale_factor_at_central_meridian": 0.9996,
+                "spatial_ref": "PROJCRS[\"WGS 84 / UTM zone 31N\",BASEGEOGCRS[\"WGS 84\",ENSEMBLE[\"World Geodetic System 1984 ensemble\",MEMBER[\"World Geodetic System 1984 (Transit)\"],MEMBER[\"World Geodetic System 1984 (G730)\"],MEMBER[\"World Geodetic System 1984 (G873)\"],MEMBER[\"World Geodetic System 1984 (G1150)\"],MEMBER[\"World Geodetic System 1984 (G1674)\"],MEMBER[\"World Geodetic System 1984 (G1762)\"],MEMBER[\"World Geodetic System 1984 (G2139)\"],MEMBER[\"World Geodetic System 1984 (G2296)\"],ELLIPSOID[\"WGS 84\",6378137,298.257223563,LENGTHUNIT[\"metre\",1]],ENSEMBLEACCURACY[2.0]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433]],ID[\"EPSG\",4326]],CONVERSION[\"UTM zone 31N\",METHOD[\"Transverse Mercator\",ID[\"EPSG\",9807]],PARAMETER[\"Latitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8801]],PARAMETER[\"Longitude of natural origin\",3,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"Scale factor at natural origin\",0.9996,SCALEUNIT[\"unity\",1],ID[\"EPSG\",8805]],PARAMETER[\"False easting\",500000,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"(E)\",east,ORDER[1],LENGTHUNIT[\"metre\",1]],AXIS[\"(N)\",north,ORDER[2],LENGTHUNIT[\"metre\",1]],USAGE[SCOPE[\"Navigation and medium accuracy spatial referencing.\"],AREA[\"Between 0\u00b0E and 6\u00b0E, northern hemisphere between equator and 84\u00b0N, onshore and offshore. Algeria. Andorra. Belgium. Benin. Burkina Faso. Denmark - North Sea. France. Germany - North Sea. Ghana. Luxembourg. Mali. Netherlands. Niger. Nigeria. Norway. Spain. Togo. United Kingdom (UK) - North Sea.\"],BBOX[0,0,84,6]],ID[\"EPSG\",32631]]",
+                "_ARRAY_DIMENSIONS": []
+              },
+              "shape": [],
+              "data_type": "int64",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": []
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": 0,
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "zstd",
+                  "configuration": {
+                    "level": 0,
+                    "checksum": false
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": null
+            },
+            "time": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "units": "nanoseconds since 1970-01-01",
+                "calendar": "proleptic_gregorian",
+                "standard_name": "time",
+                "_ARRAY_DIMENSIONS": [
+                  "time"
+                ]
+              },
+              "shape": [
+                3
+              ],
+              "data_type": "int64",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": [
+                    512
+                  ]
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": 0,
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "zstd",
+                  "configuration": {
+                    "level": 0,
+                    "checksum": false
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": [
+                "time"
+              ]
+            },
+            "vh": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "standard_name": "surface_backwards_scattering_coefficient_of_radar_wave",
+                "units": "1",
+                "_FillValue": "AAAAAAAA+H8=",
+                "grid_mapping": "spatial_ref"
+              },
+              "shape": [
+                3,
+                180,
+                180
+              ],
+              "data_type": "float32",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": [
+                    1,
+                    180,
+                    180
+                  ]
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": "NaN",
+              "codecs": [
+                {
+                  "name": "sharding_indexed",
+                  "configuration": {
+                    "chunk_shape": [
+                      1,
+                      180,
+                      180
+                    ],
+                    "codecs": [
+                      {
+                        "name": "bytes",
+                        "configuration": {
+                          "endian": "little"
+                        }
+                      },
+                      {
+                        "name": "blosc",
+                        "configuration": {
+                          "typesize": 4,
+                          "cname": "zstd",
+                          "clevel": 5,
+                          "shuffle": "shuffle",
+                          "blocksize": 0
+                        }
+                      }
+                    ],
+                    "index_codecs": [
+                      {
+                        "name": "bytes",
+                        "configuration": {
+                          "endian": "little"
+                        }
+                      },
+                      {
+                        "name": "crc32c"
+                      }
+                    ],
+                    "index_location": "end"
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": [
+                "time",
+                "y",
+                "x"
+              ]
+            },
+            "vv": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "standard_name": "surface_backwards_scattering_coefficient_of_radar_wave",
+                "units": "1",
+                "_FillValue": "AAAAAAAA+H8=",
+                "grid_mapping": "spatial_ref"
+              },
+              "shape": [
+                3,
+                180,
+                180
+              ],
+              "data_type": "float32",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": [
+                    1,
+                    180,
+                    180
+                  ]
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": "NaN",
+              "codecs": [
+                {
+                  "name": "sharding_indexed",
+                  "configuration": {
+                    "chunk_shape": [
+                      1,
+                      180,
+                      180
+                    ],
+                    "codecs": [
+                      {
+                        "name": "bytes",
+                        "configuration": {
+                          "endian": "little"
+                        }
+                      },
+                      {
+                        "name": "blosc",
+                        "configuration": {
+                          "typesize": 4,
+                          "cname": "zstd",
+                          "clevel": 5,
+                          "shuffle": "shuffle",
+                          "blocksize": 0
+                        }
+                      }
+                    ],
+                    "index_codecs": [
+                      {
+                        "name": "bytes",
+                        "configuration": {
+                          "endian": "little"
+                        }
+                      },
+                      {
+                        "name": "crc32c"
+                      }
+                    ],
+                    "index_location": "end"
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": [
+                "time",
+                "y",
+                "x"
+              ]
+            },
+            "x": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "units": "m",
+                "long_name": "x coordinate of projection",
+                "standard_name": "projection_x_coordinate",
+                "_ARRAY_DIMENSIONS": [
+                  "x"
+                ]
+              },
+              "shape": [
+                180
+              ],
+              "data_type": "float64",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": [
+                    180
+                  ]
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": "NaN",
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "zstd",
+                  "configuration": {
+                    "level": 0,
+                    "checksum": false
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": [
+                "x"
+              ]
+            },
+            "y": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "units": "m",
+                "long_name": "y coordinate of projection",
+                "standard_name": "projection_y_coordinate",
+                "_ARRAY_DIMENSIONS": [
+                  "y"
+                ]
+              },
+              "shape": [
+                180
+              ],
+              "data_type": "float64",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": [
+                    180
+                  ]
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": "NaN",
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "zstd",
+                  "configuration": {
+                    "level": 0,
+                    "checksum": false
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": [
+                "y"
+              ]
             }
           }
         },
         "r720m": {
           "zarr_format": 3,
+          "node_type": "group",
           "attributes": {
+            "spatial:dimensions": [
+              "y",
+              "x"
+            ],
             "spatial:shape": [
-              153,
-              153
+              15,
+              15
             ],
             "spatial:transform": [
               720.0,
@@ -1545,163 +3219,36 @@
               0.0,
               -720.0,
               5000000.0
-            ]
+            ],
+            "zarr_conventions": [
+              {
+                "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                "name": "spatial:",
+                "description": "Spatial coordinate information"
+              },
+              {
+                "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                "name": "proj:",
+                "description": "Coordinate reference system information for geospatial data"
+              }
+            ],
+            "proj:code": "EPSG:32631"
           },
           "members": {
-            "vv": {
-              "zarr_format": 3,
-              "node_type": "array",
-              "attributes": {},
-              "shape": [
-                3,
-                153,
-                153
-              ],
-              "data_type": "float32",
-              "chunk_grid": {
-                "name": "regular",
-                "configuration": {
-                  "chunk_shape": [
-                    1,
-                    153,
-                    153
-                  ]
-                }
-              },
-              "chunk_key_encoding": {
-                "name": "default",
-                "configuration": {
-                  "separator": "/"
-                }
-              },
-              "fill_value": "NaN",
-              "codecs": [
-                {
-                  "name": "sharding_indexed",
-                  "configuration": {
-                    "chunk_shape": [
-                      1,
-                      153,
-                      153
-                    ],
-                    "codecs": [
-                      {
-                        "name": "bytes",
-                        "configuration": {
-                          "endian": "little"
-                        }
-                      },
-                      {
-                        "name": "blosc",
-                        "configuration": {
-                          "cname": "zstd",
-                          "clevel": 5
-                        }
-                      }
-                    ],
-                    "index_codecs": [
-                      {
-                        "name": "bytes",
-                        "configuration": {
-                          "endian": "little"
-                        }
-                      },
-                      {
-                        "name": "crc32c"
-                      }
-                    ],
-                    "index_location": "end"
-                  }
-                }
-              ],
-              "storage_transformers": [],
-              "dimension_names": [
-                "time",
-                "y",
-                "x"
-              ]
-            },
-            "vh": {
-              "zarr_format": 3,
-              "node_type": "array",
-              "attributes": {},
-              "shape": [
-                3,
-                153,
-                153
-              ],
-              "data_type": "float32",
-              "chunk_grid": {
-                "name": "regular",
-                "configuration": {
-                  "chunk_shape": [
-                    1,
-                    153,
-                    153
-                  ]
-                }
-              },
-              "chunk_key_encoding": {
-                "name": "default",
-                "configuration": {
-                  "separator": "/"
-                }
-              },
-              "fill_value": "NaN",
-              "codecs": [
-                {
-                  "name": "sharding_indexed",
-                  "configuration": {
-                    "chunk_shape": [
-                      1,
-                      153,
-                      153
-                    ],
-                    "codecs": [
-                      {
-                        "name": "bytes",
-                        "configuration": {
-                          "endian": "little"
-                        }
-                      },
-                      {
-                        "name": "blosc",
-                        "configuration": {
-                          "cname": "zstd",
-                          "clevel": 5
-                        }
-                      }
-                    ],
-                    "index_codecs": [
-                      {
-                        "name": "bytes",
-                        "configuration": {
-                          "endian": "little"
-                        }
-                      },
-                      {
-                        "name": "crc32c"
-                      }
-                    ],
-                    "index_location": "end"
-                  }
-                }
-              ],
-              "storage_transformers": [],
-              "dimension_names": [
-                "time",
-                "y",
-                "x"
-              ]
-            },
             "border_mask": {
               "zarr_format": 3,
               "node_type": "array",
-              "attributes": {},
+              "attributes": {
+                "grid_mapping": "spatial_ref"
+              },
               "shape": [
                 3,
-                153,
-                153
+                15,
+                15
               ],
               "data_type": "uint8",
               "chunk_grid": {
@@ -1709,8 +3256,8 @@
                 "configuration": {
                   "chunk_shape": [
                     1,
-                    153,
-                    153
+                    15,
+                    15
                   ]
                 }
               },
@@ -1727,21 +3274,21 @@
                   "configuration": {
                     "chunk_shape": [
                       1,
-                      153,
-                      153
+                      15,
+                      15
                     ],
                     "codecs": [
                       {
-                        "name": "bytes",
-                        "configuration": {
-                          "endian": "little"
-                        }
+                        "name": "bytes"
                       },
                       {
                         "name": "blosc",
                         "configuration": {
+                          "typesize": 1,
                           "cname": "zstd",
-                          "clevel": 5
+                          "clevel": 5,
+                          "shuffle": "bitshuffle",
+                          "blocksize": 0
                         }
                       }
                     ],
@@ -1766,42 +3313,135 @@
                 "y",
                 "x"
               ]
-            }
-          }
-        },
-        "conditions": {
-          "zarr_format": 3,
-          "attributes": {
-            "proj:code": "EPSG:32631",
-            "spatial:dimensions": [
-              "y",
-              "x"
-            ],
-            "spatial:transform": [
-              10.0,
-              0.0,
-              500000.0,
-              0.0,
-              -10.0,
-              5000000.0
-            ]
-          },
-          "members": {
-            "gamma_area_008": {
+            },
+            "spatial_ref": {
               "zarr_format": 3,
               "node_type": "array",
-              "attributes": {},
+              "attributes": {
+                "crs_wkt": "PROJCRS[\"WGS 84 / UTM zone 31N\",BASEGEOGCRS[\"WGS 84\",ENSEMBLE[\"World Geodetic System 1984 ensemble\",MEMBER[\"World Geodetic System 1984 (Transit)\"],MEMBER[\"World Geodetic System 1984 (G730)\"],MEMBER[\"World Geodetic System 1984 (G873)\"],MEMBER[\"World Geodetic System 1984 (G1150)\"],MEMBER[\"World Geodetic System 1984 (G1674)\"],MEMBER[\"World Geodetic System 1984 (G1762)\"],MEMBER[\"World Geodetic System 1984 (G2139)\"],MEMBER[\"World Geodetic System 1984 (G2296)\"],ELLIPSOID[\"WGS 84\",6378137,298.257223563,LENGTHUNIT[\"metre\",1]],ENSEMBLEACCURACY[2.0]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433]],ID[\"EPSG\",4326]],CONVERSION[\"UTM zone 31N\",METHOD[\"Transverse Mercator\",ID[\"EPSG\",9807]],PARAMETER[\"Latitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8801]],PARAMETER[\"Longitude of natural origin\",3,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"Scale factor at natural origin\",0.9996,SCALEUNIT[\"unity\",1],ID[\"EPSG\",8805]],PARAMETER[\"False easting\",500000,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"(E)\",east,ORDER[1],LENGTHUNIT[\"metre\",1]],AXIS[\"(N)\",north,ORDER[2],LENGTHUNIT[\"metre\",1]],USAGE[SCOPE[\"Navigation and medium accuracy spatial referencing.\"],AREA[\"Between 0\u00b0E and 6\u00b0E, northern hemisphere between equator and 84\u00b0N, onshore and offshore. Algeria. Andorra. Belgium. Benin. Burkina Faso. Denmark - North Sea. France. Germany - North Sea. Ghana. Luxembourg. Mali. Netherlands. Niger. Nigeria. Norway. Spain. Togo. United Kingdom (UK) - North Sea.\"],BBOX[0,0,84,6]],ID[\"EPSG\",32631]]",
+                "semi_major_axis": 6378137.0,
+                "semi_minor_axis": 6356752.314245179,
+                "inverse_flattening": 298.257223563,
+                "reference_ellipsoid_name": "WGS 84",
+                "longitude_of_prime_meridian": 0.0,
+                "prime_meridian_name": "Greenwich",
+                "geographic_crs_name": "WGS 84",
+                "horizontal_datum_name": "World Geodetic System 1984 ensemble",
+                "projected_crs_name": "WGS 84 / UTM zone 31N",
+                "grid_mapping_name": "transverse_mercator",
+                "latitude_of_projection_origin": 0.0,
+                "longitude_of_central_meridian": 3.0,
+                "false_easting": 500000.0,
+                "false_northing": 0.0,
+                "scale_factor_at_central_meridian": 0.9996,
+                "spatial_ref": "PROJCRS[\"WGS 84 / UTM zone 31N\",BASEGEOGCRS[\"WGS 84\",ENSEMBLE[\"World Geodetic System 1984 ensemble\",MEMBER[\"World Geodetic System 1984 (Transit)\"],MEMBER[\"World Geodetic System 1984 (G730)\"],MEMBER[\"World Geodetic System 1984 (G873)\"],MEMBER[\"World Geodetic System 1984 (G1150)\"],MEMBER[\"World Geodetic System 1984 (G1674)\"],MEMBER[\"World Geodetic System 1984 (G1762)\"],MEMBER[\"World Geodetic System 1984 (G2139)\"],MEMBER[\"World Geodetic System 1984 (G2296)\"],ELLIPSOID[\"WGS 84\",6378137,298.257223563,LENGTHUNIT[\"metre\",1]],ENSEMBLEACCURACY[2.0]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433]],ID[\"EPSG\",4326]],CONVERSION[\"UTM zone 31N\",METHOD[\"Transverse Mercator\",ID[\"EPSG\",9807]],PARAMETER[\"Latitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8801]],PARAMETER[\"Longitude of natural origin\",3,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"Scale factor at natural origin\",0.9996,SCALEUNIT[\"unity\",1],ID[\"EPSG\",8805]],PARAMETER[\"False easting\",500000,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"(E)\",east,ORDER[1],LENGTHUNIT[\"metre\",1]],AXIS[\"(N)\",north,ORDER[2],LENGTHUNIT[\"metre\",1]],USAGE[SCOPE[\"Navigation and medium accuracy spatial referencing.\"],AREA[\"Between 0\u00b0E and 6\u00b0E, northern hemisphere between equator and 84\u00b0N, onshore and offshore. Algeria. Andorra. Belgium. Benin. Burkina Faso. Denmark - North Sea. France. Germany - North Sea. Ghana. Luxembourg. Mali. Netherlands. Niger. Nigeria. Norway. Spain. Togo. United Kingdom (UK) - North Sea.\"],BBOX[0,0,84,6]],ID[\"EPSG\",32631]]",
+                "_ARRAY_DIMENSIONS": []
+              },
+              "shape": [],
+              "data_type": "int64",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": []
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": 0,
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "zstd",
+                  "configuration": {
+                    "level": 0,
+                    "checksum": false
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": null
+            },
+            "time": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "units": "nanoseconds since 1970-01-01",
+                "calendar": "proleptic_gregorian",
+                "standard_name": "time",
+                "_ARRAY_DIMENSIONS": [
+                  "time"
+                ]
+              },
               "shape": [
-                10980,
-                10980
+                3
+              ],
+              "data_type": "int64",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": [
+                    512
+                  ]
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": 0,
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "zstd",
+                  "configuration": {
+                    "level": 0,
+                    "checksum": false
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": [
+                "time"
+              ]
+            },
+            "vh": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "standard_name": "surface_backwards_scattering_coefficient_of_radar_wave",
+                "units": "1",
+                "_FillValue": "AAAAAAAA+H8=",
+                "grid_mapping": "spatial_ref"
+              },
+              "shape": [
+                3,
+                15,
+                15
               ],
               "data_type": "float32",
               "chunk_grid": {
                 "name": "regular",
                 "configuration": {
                   "chunk_shape": [
-                    366,
-                    366
+                    1,
+                    15,
+                    15
                   ]
                 }
               },
@@ -1814,40 +3454,75 @@
               "fill_value": "NaN",
               "codecs": [
                 {
-                  "name": "bytes",
+                  "name": "sharding_indexed",
                   "configuration": {
-                    "endian": "little"
-                  }
-                },
-                {
-                  "name": "blosc",
-                  "configuration": {
-                    "cname": "zstd",
-                    "clevel": 5
+                    "chunk_shape": [
+                      1,
+                      15,
+                      15
+                    ],
+                    "codecs": [
+                      {
+                        "name": "bytes",
+                        "configuration": {
+                          "endian": "little"
+                        }
+                      },
+                      {
+                        "name": "blosc",
+                        "configuration": {
+                          "typesize": 4,
+                          "cname": "zstd",
+                          "clevel": 5,
+                          "shuffle": "shuffle",
+                          "blocksize": 0
+                        }
+                      }
+                    ],
+                    "index_codecs": [
+                      {
+                        "name": "bytes",
+                        "configuration": {
+                          "endian": "little"
+                        }
+                      },
+                      {
+                        "name": "crc32c"
+                      }
+                    ],
+                    "index_location": "end"
                   }
                 }
               ],
               "storage_transformers": [],
               "dimension_names": [
+                "time",
                 "y",
                 "x"
               ]
             },
-            "gamma_area_037": {
+            "vv": {
               "zarr_format": 3,
               "node_type": "array",
-              "attributes": {},
+              "attributes": {
+                "standard_name": "surface_backwards_scattering_coefficient_of_radar_wave",
+                "units": "1",
+                "_FillValue": "AAAAAAAA+H8=",
+                "grid_mapping": "spatial_ref"
+              },
               "shape": [
-                10980,
-                10980
+                3,
+                15,
+                15
               ],
               "data_type": "float32",
               "chunk_grid": {
                 "name": "regular",
                 "configuration": {
                   "chunk_shape": [
-                    366,
-                    366
+                    1,
+                    15,
+                    15
                   ]
                 }
               },
@@ -1860,40 +3535,73 @@
               "fill_value": "NaN",
               "codecs": [
                 {
-                  "name": "bytes",
+                  "name": "sharding_indexed",
                   "configuration": {
-                    "endian": "little"
-                  }
-                },
-                {
-                  "name": "blosc",
-                  "configuration": {
-                    "cname": "zstd",
-                    "clevel": 5
+                    "chunk_shape": [
+                      1,
+                      15,
+                      15
+                    ],
+                    "codecs": [
+                      {
+                        "name": "bytes",
+                        "configuration": {
+                          "endian": "little"
+                        }
+                      },
+                      {
+                        "name": "blosc",
+                        "configuration": {
+                          "typesize": 4,
+                          "cname": "zstd",
+                          "clevel": 5,
+                          "shuffle": "shuffle",
+                          "blocksize": 0
+                        }
+                      }
+                    ],
+                    "index_codecs": [
+                      {
+                        "name": "bytes",
+                        "configuration": {
+                          "endian": "little"
+                        }
+                      },
+                      {
+                        "name": "crc32c"
+                      }
+                    ],
+                    "index_location": "end"
                   }
                 }
               ],
               "storage_transformers": [],
               "dimension_names": [
+                "time",
                 "y",
                 "x"
               ]
             },
-            "gamma_area_110": {
+            "x": {
               "zarr_format": 3,
               "node_type": "array",
-              "attributes": {},
+              "attributes": {
+                "units": "m",
+                "long_name": "x coordinate of projection",
+                "standard_name": "projection_x_coordinate",
+                "_ARRAY_DIMENSIONS": [
+                  "x"
+                ]
+              },
               "shape": [
-                10980,
-                10980
+                15
               ],
-              "data_type": "float32",
+              "data_type": "float64",
               "chunk_grid": {
                 "name": "regular",
                 "configuration": {
                   "chunk_shape": [
-                    366,
-                    366
+                    15
                   ]
                 }
               },
@@ -1912,17 +3620,66 @@
                   }
                 },
                 {
-                  "name": "blosc",
+                  "name": "zstd",
                   "configuration": {
-                    "cname": "zstd",
-                    "clevel": 5
+                    "level": 0,
+                    "checksum": false
                   }
                 }
               ],
               "storage_transformers": [],
               "dimension_names": [
-                "y",
                 "x"
+              ]
+            },
+            "y": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "units": "m",
+                "long_name": "y coordinate of projection",
+                "standard_name": "projection_y_coordinate",
+                "_ARRAY_DIMENSIONS": [
+                  "y"
+                ]
+              },
+              "shape": [
+                15
+              ],
+              "data_type": "float64",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": [
+                    15
+                  ]
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": "NaN",
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "zstd",
+                  "configuration": {
+                    "level": 0,
+                    "checksum": false
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": [
+                "y"
               ]
             }
           }

--- a/tests/test_data_api/test_s1_rtc.py
+++ b/tests/test_data_api/test_s1_rtc.py
@@ -6,15 +6,35 @@ These tests verify that S1 RTC GeoZarr V3 store metadata can be:
 2. Validated through Pydantic models
 3. Round-tripped without data loss
 4. Rejects invalid structures
+
+The JSON-driven tests read ``tests/_test_data/s1_rtc_examples/*.json`` through the
+``s1_rtc_json_example`` fixture. Those files are NOT hand-maintained: regenerate them with
+``tests/_test_data/s1_rtc_examples/regenerate.py``, which dumps a store built by the real
+ingester. A hand-edited fixture is how this model came to reject every store the writer
+produced while the suite stayed green — see ``TestWriterRoundTrip`` below, which validates
+against a freshly ingested store and is the check that cannot go stale.
 """
 
 from __future__ import annotations
 
 import copy
+from typing import TYPE_CHECKING
 
+import numpy as np
 import pytest
+import zarr
 
+from eopf_geozarr.conversion.s1_ingest import (
+    consolidate_s1_store,
+    ingest_s1tiling_acquisition,
+    ingest_s1tiling_conditions,
+)
+from eopf_geozarr.data_api.s1_rtc import CONDITION_ARRAY_PREFIXES as _CONDITION_PREFIXES
 from eopf_geozarr.data_api.s1_rtc import S1RtcRoot
+from tests.test_s1_rtc_ingest import ACQ1_TAGS, SIZE, _create_synthetic_geotiff
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _nav(node: object, *keys: str) -> dict[str, object]:
@@ -69,8 +89,13 @@ def test_s1_rtc_overview_levels(s1_rtc_json_example: dict[str, object]) -> None:
         assert "vv" in group.members
         assert "vh" in group.members
         assert "border_mask" in group.members
-        # Overview levels should NOT have coordinate arrays
-        assert "time" not in group.members
+        # Overview levels DO carry the coordinate arrays. `time` is replicated at every level
+        # with identical values (data-model #192): TiTiler renders previews off a coarse level,
+        # and a level without `time` cannot be selected by datetime. This assertion used to
+        # demand the opposite -- it was written against a fixture that predated #192, and it is
+        # the reason a writer/model mismatch survived in the suite.
+        for coord in ("time", "x", "y", "spatial_ref"):
+            assert coord in group.members, f"{level} is missing the {coord!r} coordinate"
 
 
 def test_s1_rtc_conditions(s1_rtc_json_example: dict[str, object]) -> None:
@@ -130,15 +155,231 @@ def test_s1_rtc_rejects_bad_spatial_dimensions(s1_rtc_json_example: dict[str, ob
         S1RtcRoot.model_validate(data)
 
 
-def test_s1_rtc_rejects_conditions_without_gamma_area(
+def test_s1_rtc_rejects_conditions_without_condition_arrays(
     s1_rtc_json_example: dict[str, object],
 ) -> None:
-    """Reject conditions group with no gamma_area_* arrays."""
+    """Reject a conditions group holding no condition array at all.
+
+    Keeps the coordinate arrays so this exercises the condition-array check specifically —
+    stripping them too would trip `validate_coordinate_arrays` first and the test would pass
+    for the wrong reason.
+    """
     data = copy.deepcopy(s1_rtc_json_example)
     cond_members = _nav(data, "members", "descending", "members", "conditions", "members")
-    # Replace all keys with non-gamma_area names
-    _nav(data, "members", "descending", "members", "conditions")["members"] = {
-        "some_other": next(iter(cond_members.values()))
+    kept = {name: spec for name, spec in cond_members.items() if name in ("x", "y", "spatial_ref")}
+    assert set(kept) == {"x", "y", "spatial_ref"}, "fixture lost its conditions coordinates"
+    kept["some_other"] = next(iter(cond_members.values()))
+    _nav(data, "members", "descending", "members", "conditions")["members"] = kept
+    with pytest.raises(Exception, match="at least one condition array"):
+        S1RtcRoot.model_validate(data)
+
+
+def test_s1_rtc_accepts_lia_only_conditions(s1_rtc_json_example: dict[str, object]) -> None:
+    """Accept a conditions group with `lia_*` but no `gamma_area_*`.
+
+    `ingest_s1tiling_conditions` requires only that *one* of its three condition paths be
+    given, and the CLI's three condition flags all default to None, so a lia-only conditions
+    group is writable today. Demanding `gamma_area_*` specifically made such a store
+    unopenable by this model.
+    """
+    data = copy.deepcopy(s1_rtc_json_example)
+    conditions = _nav(data, "members", "descending", "members", "conditions")
+    cond_members = _nav(data, "members", "descending", "members", "conditions", "members")
+    conditions["members"] = {
+        name.replace("gamma_area_", "lia_"): spec for name, spec in cond_members.items()
     }
-    with pytest.raises(Exception, match="gamma_area"):
+    model = S1RtcRoot.model_validate(data)
+    assert model.descending is not None
+    assert model.descending.conditions is not None
+
+
+# =============================================================================
+# Writer ↔ model round-trip
+# =============================================================================
+
+
+def _condition_geotiff(tmp_path: Path, name: str) -> Path:
+    """Write a synthetic (Y, X) condition raster on the ingest tests' reference grid."""
+    path = tmp_path / f"{name}.tif"
+    rng = np.random.default_rng(len(name))
+    _create_synthetic_geotiff(path, rng.uniform(0.5, 2.0, (SIZE, SIZE)).astype(np.float32))
+    return path
+
+
+def _ingest_store(tmp_path: Path, condition_kwargs: list[str]) -> Path:
+    """Build a real S1 RTC store with the production ingester and return its path."""
+    rng = np.random.default_rng(216)
+    store_path = tmp_path / "s1-grd-rtc-roundtrip.zarr"
+
+    vv = tmp_path / "acq_vv.tif"
+    vh = tmp_path / "acq_vh.tif"
+    mask = tmp_path / "acq_mask.tif"
+    for path, data in (
+        (vv, rng.uniform(0.0, 1.0, (SIZE, SIZE)).astype(np.float32)),
+        (vh, rng.uniform(0.0, 0.5, (SIZE, SIZE)).astype(np.float32)),
+        (mask, np.ones((SIZE, SIZE), dtype=np.uint8)),
+    ):
+        _create_synthetic_geotiff(path, data, tags=ACQ1_TAGS)
+    ingest_s1tiling_acquisition(vv, vh, mask, store_path, "ascending")
+
+    ingest_s1tiling_conditions(
+        store_path=store_path,
+        orbit_direction="ascending",
+        relative_orbit=37,
+        **{
+            kwarg: _condition_geotiff(tmp_path, kwarg.removesuffix("_path"))
+            for kwarg in condition_kwargs
+        },
+    )
+    consolidate_s1_store(store_path, "ascending")
+    return store_path
+
+
+def _open_store(store_path: Path) -> zarr.Group:
+    return zarr.open_group(str(store_path), mode="r", zarr_format=3)
+
+
+class TestWriterRoundTrip:
+    """Validate the model against stores this repo's own writer produces.
+
+    Every other test in this module runs off a checked-in JSON fixture, which is why the model
+    could reject 23 arrays that the ingester has always written (`x`, `y` and `spatial_ref` at
+    every level, plus per-level `time` since data-model #192) without a single test noticing.
+    These tests close the loop in both directions: a freshly ingested store must validate, and
+    a store with a coordinate removed must not.
+    """
+
+    @pytest.mark.parametrize(
+        "condition_kwargs",
+        [
+            pytest.param(["gamma_area_path"], id="gamma-only"),
+            # lia-only is reachable from the CLI (all three condition flags default to None),
+            # so the model has to open it -- see test_s1_rtc_accepts_lia_only_conditions.
+            pytest.param(["lia_path"], id="lia-only"),
+            pytest.param(
+                ["gamma_area_path", "lia_path", "incidence_angle_path"], id="all-conditions"
+            ),
+        ],
+    )
+    def test_ingested_store_validates(self, tmp_path: Path, condition_kwargs: list[str]) -> None:
+        """A store built by the ingester opens through the model."""
+        store_path = _ingest_store(tmp_path, condition_kwargs)
+
+        model = S1RtcRoot.from_zarr(_open_store(store_path))
+
+        assert model.ascending is not None
+        assert model.ascending.conditions is not None
+        for level in ("r10m", "r20m", "r60m", "r120m", "r360m", "r720m"):
+            group = model.ascending.get_resolution(level)
+            assert group is not None, f"missing level {level}"
+            for coord in ("time", "x", "y", "spatial_ref"):
+                assert coord in group.members, f"{level} lost {coord!r}"
+
+    @pytest.mark.parametrize("coordinate", ["time", "x", "y", "spatial_ref"])
+    def test_overview_missing_coordinate_is_rejected(self, tmp_path: Path, coordinate: str) -> None:
+        """Deleting a coordinate from one overview level must fail validation.
+
+        This is the regression the model exists to catch: `time` was absent from the overview
+        levels before data-model #192, which broke datetime `.sel` on exactly the coarse levels
+        TiTiler renders previews from. Listing the keys in the member TypedDicts would NOT catch
+        it -- they are `total=False`, so every key is NotRequired and a *missing* one is legal --
+        which is why both dataset classes carry an explicit presence validator.
+        """
+        store_path = _ingest_store(tmp_path, ["gamma_area_path"])
+        # Sanity: the untouched store validates, so a failure below is the deletion talking.
+        S1RtcRoot.from_zarr(_open_store(store_path))
+
+        orbit = zarr.open_group(
+            str(store_path / "ascending"), mode="r+", zarr_format=3, use_consolidated=False
+        )
+        level = orbit["r60m"]
+        assert isinstance(level, zarr.Group)
+        del level[coordinate]
+        consolidate_s1_store(store_path, "ascending")
+
+        with pytest.raises(Exception, match="coordinate arrays"):
+            S1RtcRoot.from_zarr(_open_store(store_path))
+
+    def test_fixture_still_matches_writer_output(
+        self, tmp_path: Path, s1_rtc_json_example: dict[str, object]
+    ) -> None:
+        """The checked-in fixture must keep describing what the writer actually emits.
+
+        The fixture is a writer snapshot produced by
+        ``tests/_test_data/s1_rtc_examples/regenerate.py``. Nothing else compares the two, so a
+        hand-edit (or a writer change made without regenerating) would silently reopen the drift
+        this module exists to close -- one level down from the original bug.
+
+        Compares member *names* per group, which is what the closed TypedDicts and the coordinate
+        validators actually read. Condition array names are orbit-suffixed and differ between the
+        fixture's tile and this synthetic store, so they are compared by prefix, not verbatim.
+        """
+        store_path = _ingest_store(tmp_path, ["gamma_area_path"])
+        ingested = S1RtcRoot.from_zarr(_open_store(store_path))
+
+        fixture_orbit = _nav(s1_rtc_json_example, "members", "descending")
+        ingested_root = ingested.model_dump(by_alias=True, mode="json")
+        ingested_orbit = _nav(ingested_root, "members", "ascending")
+
+        fixture_levels = _nav(fixture_orbit, "members")
+        ingested_levels = _nav(ingested_orbit, "members")
+        assert set(fixture_levels) == set(ingested_levels), (
+            "the fixture and the writer disagree on the orbit group's members; "
+            "re-run tests/_test_data/s1_rtc_examples/regenerate.py"
+        )
+
+        for level in ("r10m", "r20m", "r60m", "r120m", "r360m", "r720m"):
+            fixture_members = set(_nav(fixture_levels, level, "members"))
+            ingested_members = set(_nav(ingested_levels, level, "members"))
+            assert fixture_members == ingested_members, (
+                f"{level} members drifted from writer output; "
+                "re-run tests/_test_data/s1_rtc_examples/regenerate.py"
+            )
+
+        # Conditions: coordinates verbatim, condition rasters by prefix (orbit suffixes differ).
+        def _split(members: set[str]) -> tuple[set[str], set[str]]:
+            conditions = {m.rsplit("_", 1)[0] for m in members if m.startswith(_CONDITION_PREFIXES)}
+            return members - {m for m in members if m.startswith(_CONDITION_PREFIXES)}, conditions
+
+        fixture_coords, fixture_conditions = _split(
+            set(_nav(fixture_levels, "conditions", "members"))
+        )
+        ingested_coords, ingested_conditions = _split(
+            set(_nav(ingested_levels, "conditions", "members"))
+        )
+        assert fixture_coords == ingested_coords, (
+            "conditions-group coordinates drifted from writer output; "
+            "re-run tests/_test_data/s1_rtc_examples/regenerate.py"
+        )
+        assert ingested_conditions <= fixture_conditions
+
+
+@pytest.mark.parametrize("coordinate", ["time", "x", "y", "spatial_ref"])
+def test_native_missing_coordinate_is_rejected(
+    s1_rtc_json_example: dict[str, object], coordinate: str
+) -> None:
+    """The native level is validated by the same rule as the overviews.
+
+    `test_overview_missing_coordinate_is_rejected` only deletes from an overview level, so
+    without this the native validator could be removed and the suite would stay green.
+    """
+    data = copy.deepcopy(s1_rtc_json_example)
+    del _nav(data, "members", "descending", "members", "r10m", "members")[coordinate]
+    with pytest.raises(Exception, match="coordinate arrays"):
+        S1RtcRoot.model_validate(data)
+
+
+@pytest.mark.parametrize("coordinate", ["x", "y", "spatial_ref"])
+def test_conditions_missing_coordinate_is_rejected(
+    s1_rtc_json_example: dict[str, object], coordinate: str
+) -> None:
+    """A conditions group without 1-D coordinates is not georeferenced at all.
+
+    It opens with "dimensions without coordinates" and rioxarray infers an identity transform,
+    which is the same class of defect the level-coordinate validators exist to catch. The
+    conditions group carries no `time` (its rasters are time-invariant).
+    """
+    data = copy.deepcopy(s1_rtc_json_example)
+    del _nav(data, "members", "descending", "members", "conditions", "members")[coordinate]
+    with pytest.raises(Exception, match="coordinate arrays"):
         S1RtcRoot.model_validate(data)

--- a/tests/test_s1_stac.py
+++ b/tests/test_s1_stac.py
@@ -9,6 +9,7 @@ import numpy as np
 
 if TYPE_CHECKING:
     from pathlib import Path
+import pyproj
 import pytest
 import zarr
 
@@ -29,6 +30,10 @@ UTM_BBOX = make_bounding_box([300000.0, 4900000.0, 400000.0, 5000000.0])  # (xmi
 T1_NS = int(np.datetime64("2023-01-15T06:12:34", "ns").astype(np.int64))
 T2_NS = int(np.datetime64("2023-01-27T06:12:35", "ns").astype(np.int64))
 
+# (first absolute orbit, relative orbit) written per orbit direction by the fixture below. Ascending
+# and descending passes over one tile are different tracks, so they differ in both.
+_DEFAULT_ORBIT_NUMBERS = {"ascending": (58011, 37), "descending": (57050, 110)}
+
 
 # =============================================================================
 # Fixture helper
@@ -42,6 +47,8 @@ def _make_s1_store(
     crs: str = CRS,
     utm_bbox: BoundingBox2D | None = None,
     consolidate: bool = True,
+    orbit_numbers: bool = True,
+    relative_orbits: list[int] | None = None,
 ) -> Path:
     """Create a minimal S1 Zarr store.
 
@@ -49,6 +56,9 @@ def _make_s1_store(
     Creates only the attrs and coordinate arrays needed by build_s1_rtc_stac_item.
     ``consolidate=False`` skips writing root consolidated metadata, mirroring a cube that grew by
     appending a time-slice to an existing same-orbit group (the builder must still read it).
+    ``orbit_numbers=False`` omits the absolute/relative orbit coordinates entirely, mirroring a
+    store written before ``s1_ingest`` recorded them; ``relative_orbits`` overrides the default
+    single-track relative orbit (to build a cube covered by more than one track).
     """
     if utm_bbox is None:
         utm_bbox = UTM_BBOX
@@ -75,6 +85,18 @@ def _make_s1_store(
         t_arr[:] = times
         p_arr = r10m.create_array("platform", shape=platforms.shape, dtype="<U4", chunks=(512,))
         p_arr[:] = platforms
+        if orbit_numbers:
+            # int32 `time` coords, exactly as s1_ingest.py writes them at native resolution. The
+            # defaults model one track per orbit direction (the two directions are different tracks,
+            # hence different relative orbits), with an absolute orbit unique per acquisition —
+            # which is why only the relative orbit survives into a multi-slice cube.
+            base_abs, default_rel = _DEFAULT_ORBIT_NUMBERS[orbit_dir]
+            for name, values in (
+                ("absolute_orbit", [base_abs + i for i in range(nt)]),
+                ("relative_orbit", list(relative_orbits or [default_rel] * nt)),
+            ):
+                arr = r10m.create_array(name, shape=(nt,), dtype="int32", chunks=(512,))
+                arr[:] = np.array(values, dtype="int32")
         # Data variables (named bands the builder advertises); tiny so creation stays cheap.
         for name, dtype in (("vv", "float32"), ("vh", "float32"), ("border_mask", "uint8")):
             arr = r10m.create_array(name, shape=(nt, ny, nx), dtype=dtype, chunks=(1, ny, nx))
@@ -300,14 +322,85 @@ def test_orbit_state_single_vs_dual(tmp_path: Path) -> None:
     assert "orbit" in item2.properties["cube:dimensions"]["time"]["description"].lower()
 
 
-def test_timestamps_updated_only(tmp_path: Path) -> None:
-    """`updated` (build time) is set; `created` is omitted — the store records no item-creation time,
-    so an acquisition time would misuse the field and a build-time value would churn on every append."""
+def test_created_and_updated_are_common_metadata_not_the_timestamps_extension(
+    tmp_path: Path,
+) -> None:
+    """`created`/`updated` are both set (STAC Common Metadata) and the timestamps extension is NOT
+    declared.
+
+    The extension was declared but inert: it only adds `published`/`expires`/`unpublished`, none of
+    which this builder emits, so it made every consumer fetch a schema that constrained nothing
+    while `created`/`updated` were validated by the core Item spec regardless. `created` was
+    previously omitted altogether; the collection requires it, and the store records no separate
+    item-creation instant, so it tracks the metadata build like `updated`.
+    """
     store = _make_s1_store(tmp_path, {"descending": [(T1_NS, "S1A"), (T2_NS, "S1A")]})
     item = build_s1_rtc_stac_item(str(store), "sentinel-1-grd-rtc-staging")
 
-    assert "created" not in item.properties
+    assert dt.datetime.fromisoformat(item.properties["created"])
     assert dt.datetime.fromisoformat(item.properties["updated"])
+    assert "https://stac-extensions.github.io/timestamps/v1.1.0/schema.json" not in (
+        item.stac_extensions
+    )
+    # No timestamps-extension field is emitted, which is why declaring it was pointless.
+    assert not {"published", "expires", "unpublished"} & set(item.properties)
+
+
+def test_providers_copied_down_from_the_collection(tmp_path: Path) -> None:
+    """Each item carries its own `providers`: a STAC API search returns items without their
+    collection, so an item that omits the block has no attribution for those consumers."""
+    store = _make_s1_store(tmp_path, {"descending": [(T1_NS, "S1A")]})
+    item = build_s1_rtc_stac_item(str(store), "sentinel-1-grd-rtc-staging")
+
+    providers = item.properties["providers"]
+    assert {p["name"] for p in providers} == {
+        "European Commission",
+        "ESA",
+        "EOPF Sentinel Zarr Samples Service",
+    }
+    licensor = next(p for p in providers if "licensor" in p["roles"])
+    assert licensor["name"] == "European Commission"
+    assert all(p["url"].startswith("https://") for p in providers)
+
+
+def test_sat_orbit_numbers_from_the_store_coordinates(tmp_path: Path) -> None:
+    """`sat:relative_orbit`/`sat:absolute_orbit` come from the int32 r10m coordinates, and each is
+    emitted only where the cube agrees on a single value (both are single-valued STAC fields)."""
+    one = _make_s1_store(tmp_path / "one", {"descending": [(T1_NS, "S1A")]})
+    props = build_s1_rtc_stac_item(str(one), "sentinel-1-grd-rtc-staging").properties
+    assert props["sat:relative_orbit"] == 110
+    assert props["sat:absolute_orbit"] == 57050
+
+    # Two acquisitions on one track: relative orbit still agrees, absolute orbit does not.
+    two = _make_s1_store(tmp_path / "two", {"descending": [(T1_NS, "S1A"), (T2_NS, "S1A")]})
+    props = build_s1_rtc_stac_item(str(two), "sentinel-1-grd-rtc-staging").properties
+    assert props["sat:relative_orbit"] == 110
+    assert "sat:absolute_orbit" not in props
+
+    # A tile covered by two tracks: neither field can describe the whole cube.
+    tracks = _make_s1_store(
+        tmp_path / "tracks",
+        {"descending": [(T1_NS, "S1A"), (T2_NS, "S1A")]},
+        relative_orbits=[110, 37],
+    )
+    props = build_s1_rtc_stac_item(str(tracks), "sentinel-1-grd-rtc-staging").properties
+    assert "sat:relative_orbit" not in props
+    assert "sat:absolute_orbit" not in props
+
+
+def test_orbit_numbers_are_read_best_effort(tmp_path: Path) -> None:
+    """A store written before `s1_ingest` recorded the orbit coordinates must still build — without
+    the sat:*_orbit fields, and (with no other sat:* field) without declaring the SAT extension."""
+    store = _make_s1_store(
+        tmp_path,
+        {"ascending": [(T1_NS, "S1A")], "descending": [(T1_NS, "S1A")]},
+        orbit_numbers=False,
+    )
+    item = build_s1_rtc_stac_item(str(store), "sentinel-1-grd-rtc-staging")
+
+    assert item.id == "s1-rtc-31TCH"
+    assert not [k for k in item.properties if k.startswith("sat:")]
+    assert "https://stac-extensions.github.io/sat/v1.0.0/schema.json" not in item.stac_extensions
 
 
 def test_sar_extension_fields(tmp_path: Path) -> None:
@@ -334,11 +427,46 @@ def test_render_extension_rgb_composite(tmp_path: Path) -> None:
     render_ext_uri = "https://stac-extensions.github.io/render/v1.0.0/schema.json"
     assert render_ext_uri in item.stac_extensions
 
-    rgb = item.properties["renders"]["rgb"]
+    rgb = item.to_dict(include_self_link=False)["renders"]["rgb"]
     assert rgb["expression"] == "/descending:vv;/descending:vh;(/descending:vv)/(/descending:vh)"
     assert rgb["rescale"] == [[0.0, 0.4], [0.0, 0.1], [1.0, 15.0]]
     assert rgb["bidx"] == [1]
+    # `tilesize` is not a render-extension field, but the Render Object sets
+    # `additionalProperties: true`, so it validates; titiler reads it to size rendered tiles.
     assert rgb["tilesize"] == 256
+
+
+def test_render_objects_carry_the_required_assets_field(tmp_path: Path) -> None:
+    """Every Render Object must name the asset(s) it renders.
+
+    `assets` is the ONE required field of a Render Object (render v1.0.0,
+    `definitions/fields.required`). Emitting a render config without it made every item fail the
+    extension it declared — `'assets' is a required property` — so `generate-stac-s1 |
+    stac-validator` failed and a validating STAC API refused the item. The value must name an asset
+    the item actually has, or the render config points at nothing.
+
+    The PLACEMENT is pinned too. Render v1.0.0's Item branch is
+    `required: ["type", "assets", "renders"]` against the item object itself, and the extension's
+    own `examples/item-landsat8.json` puts `renders` at the root — only the README's "Item
+    Properties" table says otherwise, and it contradicts both. Emitting it under `properties`
+    still failed validation, with the misleading message `'renders' is a required property`.
+    """
+    store = _make_s1_store(
+        tmp_path, {"ascending": [(T1_NS, "S1A")], "descending": [(T1_NS, "S1A")]}
+    )
+    item = build_s1_rtc_stac_item(str(store), "sentinel-1-grd-rtc-staging")
+    item_dict = item.to_dict(include_self_link=False)
+
+    assert "renders" in item_dict, "render v1.0.0 requires `renders` at the item root"
+    assert "renders" not in item_dict["properties"], (
+        "`renders` under properties does not satisfy the render extension"
+    )
+
+    for render in item_dict["renders"].values():
+        assert render["assets"], "render v1.0.0 requires a non-empty `assets`"
+        assert all(name in item.assets for name in render["assets"])
+    # Ascending is preferred, so the default render points at the ascending γ⁰ asset.
+    assert item_dict["renders"]["rgb"]["assets"] == ["gamma0-rtc-backscatter-asc"]
 
 
 def test_render_uses_ascending_when_preferred(tmp_path: Path) -> None:
@@ -356,7 +484,9 @@ def test_render_uses_ascending_when_preferred(tmp_path: Path) -> None:
     zarr.consolidate_metadata(str(store_path), zarr_format=3)
 
     item = build_s1_rtc_stac_item(str(store_path), "sentinel-1-grd-rtc-staging")
-    assert item.properties["renders"]["rgb"]["expression"].startswith("/ascending:vv")
+    assert item.to_dict(include_self_link=False)["renders"]["rgb"]["expression"].startswith(
+        "/ascending:vv"
+    )
 
 
 def test_open_root_never_creates_a_store(tmp_path: Path) -> None:
@@ -385,3 +515,227 @@ def test_open_root_reads_both_consolidated_and_unconsolidated(tmp_path: Path) ->
 
     zarr.consolidate_metadata(str(store_path), zarr_format=3)
     assert "marker" in dict(_open_root(str(store_path)).members())
+
+
+# =============================================================================
+# Tile id derivation (item id + grid:code)
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    ("store_name", "expected_remainder"),
+    [
+        # A store not following the naming convention at all: silently produced item id
+        # "s1-rtc-cube" and grid:code "MGRS-cube".
+        ("cube.zarr", "cube"),
+        # A suffixed rerun: "MGRS-31TCH_v2" is not a tile any search will ever join on.
+        ("s1-rtc-31TCH_v2.zarr", "31TCH_v2"),
+        # An empty tile: item id "s1-rtc-", grid:code "MGRS-".
+        ("s1-rtc-.zarr", ""),
+        # Lower case is not an MGRS tile id, and would not match a tile-filtered search.
+        ("s1-rtc-31tch.zarr", "31tch"),
+        # `I` is excluded from the MGRS 100 km square letters (it reads as 1).
+        ("s1-rtc-31TIH.zarr", "31TIH"),
+        # Zone numbers stop at 60.
+        ("s1-rtc-61TCH.zarr", "61TCH"),
+    ],
+)
+def test_malformed_tile_id_raises_instead_of_registering(
+    tmp_path: Path, store_name: str, expected_remainder: str
+) -> None:
+    """A store name that yields no valid MGRS tile must fail the build, not mint a malformed id.
+
+    None of these failed anywhere downstream before: they registered cleanly and poisoned the
+    catalogue, because `grid:code` is the field tile-filtered searches and the cube↔acquisition
+    cross-links join on.
+    """
+    store = _make_s1_store(tmp_path, {"descending": [(T1_NS, "S1A")]})
+    renamed = store.with_name(store_name)
+    store.rename(renamed)
+
+    with pytest.raises(ValueError, match="MGRS tile id") as excinfo:
+        build_s1_rtc_stac_item(str(renamed), "sentinel-1-grd-rtc-staging")
+    # The message must show what it actually derived, or the operator cannot see the typo.
+    assert repr(expected_remainder) in str(excinfo.value)
+
+
+def test_legacy_store_prefix_still_yields_the_bare_tile_id(tmp_path: Path) -> None:
+    """`s1-grd-rtc-` is what #246 reverts the store prefix to once titiler-eopf#108 lands.
+
+    Stripping only `s1-rtc-` left the whole name as the tile: item id `s1-rtc-s1-grd-rtc-31TCH`,
+    grid:code `MGRS-s1-grd-rtc-31TCH`. Accepting both prefixes means that rename is not a fleet-wide
+    build failure the day it happens.
+    """
+    store = _make_s1_store(tmp_path, {"descending": [(T1_NS, "S1A")]})
+    renamed = store.with_name("s1-grd-rtc-31TCH.zarr")
+    store.rename(renamed)
+
+    item = build_s1_rtc_stac_item(str(renamed), "sentinel-1-grd-rtc-staging")
+    assert item.id == "s1-rtc-31TCH"
+    assert item.properties["grid:code"] == "MGRS-31TCH"
+
+
+# =============================================================================
+# Antimeridian / densified reprojection
+# =============================================================================
+
+
+def test_zone_1_bbox_stays_narrow_and_crosses_the_antimeridian(tmp_path: Path) -> None:
+    """UTM zone 1 (and 60) must not produce a near-global footprint.
+
+    Transforming only the corners put the west edge just *east* of the antimeridian and the east
+    edge just *west* of it, so min/max straddled the wrap: tile 01VCK came out as
+    (-178.41, 54.11, 179.94, 55.13) — 358.4 degrees wide, a footprint matching almost every spatial
+    search on Earth. The densified `transform_bounds` returns the crossing box instead (west > east,
+    per STAC/GeoJSON), which is ~1.75 degrees wide.
+    """
+    store = _make_s1_store(
+        tmp_path,
+        {"descending": [(T1_NS, "S1A")]},
+        tile_id="01VCK",
+        crs=make_crs_code("EPSG:32601"),
+        utm_bbox=make_bounding_box([300000.0, 6000000.0, 409800.0, 6109800.0]),
+    )
+    item = build_s1_rtc_stac_item(str(store), "sentinel-1-grd-rtc-staging")
+
+    assert item.bbox is not None
+    west, south, east, north = item.bbox
+    assert west > east, "an antimeridian-crossing bbox is expressed as west > east"
+    assert (east + 360.0) - west == pytest.approx(1.75, abs=0.1)
+    assert (south, north) == pytest.approx((54.109, 55.127), abs=0.01)
+
+    # A single ring from west to east would run the long way round the globe; GeoJSON requires the
+    # footprint be split at ±180 instead.
+    geometry = item.geometry
+    assert geometry is not None
+    assert geometry["type"] == "MultiPolygon"
+    lons = [pt[0] for poly in geometry["coordinates"] for ring in poly for pt in ring]
+    assert max(lons) == 180.0
+    assert min(lons) == -180.0
+
+
+def test_non_crossing_bbox_is_unchanged_and_stays_a_polygon(tmp_path: Path) -> None:
+    """The antimeridian handling must not perturb the ordinary case (EPSG:32631, zone 31)."""
+    store = _make_s1_store(tmp_path, {"descending": [(T1_NS, "S1A")]})
+    item = build_s1_rtc_stac_item(str(store), "sentinel-1-grd-rtc-staging")
+
+    assert item.bbox is not None
+    west, south, east, north = item.bbox
+    assert west < east
+    assert (west, south, east, north) == pytest.approx((0.457, 44.226, 1.748, 45.146), abs=0.01)
+    assert item.geometry is not None
+    assert item.geometry["type"] == "Polygon"
+
+
+def test_bbox_union_across_orbits_does_not_wrap_the_globe(tmp_path: Path) -> None:
+    """Unioning two crossing bboxes with a plain min(west)/max(east) reinstates the 358-degree box.
+
+    Both orbit groups of a zone-1 tile cross the antimeridian, so the naive union picks the
+    westmost west and the eastmost east straight back out of the crossing pair.
+    """
+    store_path = tmp_path / "s1-rtc-01VCK.zarr"
+    root = zarr.open_group(str(store_path), mode="w", zarr_format=3)
+    for orbit_dir, bbox in [
+        ("descending", [300000.0, 6000000.0, 409800.0, 6109800.0]),
+        ("ascending", [409800.0, 6000000.0, 509800.0, 6109800.0]),
+    ]:
+        og = root.create_group(orbit_dir)
+        og.attrs.update({"proj:code": "EPSG:32601", "spatial:bbox": bbox})
+        r10m = og.create_group("r10m")
+        r10m.create_array("time", shape=(1,), dtype="int64", chunks=(512,))[:] = [T1_NS]
+        r10m.create_array("platform", shape=(1,), dtype="<U4", chunks=(512,))[:] = ["S1A"]
+    zarr.consolidate_metadata(str(store_path), zarr_format=3)
+
+    item = build_s1_rtc_stac_item(str(store_path), "sentinel-1-grd-rtc-staging")
+
+    assert item.bbox is not None
+    west, _south, east, _north = item.bbox
+    assert west > east  # still one crossing box, not an inverted global one
+    assert (east + 360.0) - west < 5.0, f"union wrapped the globe: {item.bbox}"
+
+
+# =============================================================================
+# Projection edge cases
+# =============================================================================
+
+
+def test_reference_system_falls_back_to_wkt_when_there_is_no_epsg_code(tmp_path: Path) -> None:
+    """`to_epsg()` returns None for a CRS with no EPSG match, and that None used to be emitted as a
+    literal `null` reference_system — telling a reader nothing about the grid.
+
+    datacube v2.2.0 accepts an EPSG integer, a WKT2 string or a PROJJSON object there, so fall back
+    to WKT2. `proj:code` is only validated as a non-empty pyproj-parseable string, so a WKT2 value
+    reaches the builder intact.
+    """
+    wkt = pyproj.CRS.from_user_input(
+        "+proj=laea +lat_0=52 +lon_0=10 +x_0=4321000 +y_0=3210000 +datum=WGS84 +units=m +no_defs"
+    ).to_wkt()
+    assert pyproj.CRS.from_user_input(wkt).to_epsg() is None  # the precondition being handled
+
+    store = _make_s1_store(
+        tmp_path,
+        {"descending": [(T1_NS, "S1A")]},
+        crs=make_crs_code(wkt),
+        utm_bbox=make_bounding_box([4000000.0, 3000000.0, 4100000.0, 3100000.0]),
+    )
+    item = build_s1_rtc_stac_item(str(store), "sentinel-1-grd-rtc-staging")
+
+    dims = item.properties["cube:dimensions"]
+    assert dims["x"]["reference_system"] == dims["y"]["reference_system"]
+    assert dims["x"]["reference_system"].startswith("PROJCRS[")
+
+
+def test_reference_system_is_the_epsg_int_when_there_is_one(tmp_path: Path) -> None:
+    """The WKT fallback must not displace the plain EPSG integer for a normal UTM store."""
+    store = _make_s1_store(tmp_path, {"descending": [(T1_NS, "S1A")]})
+    item = build_s1_rtc_stac_item(str(store), "sentinel-1-grd-rtc-staging")
+
+    assert item.properties["cube:dimensions"]["x"]["reference_system"] == 32631
+
+
+def _set_orbit_coord(store: Path, orbit: str, name: str, values: list[int]) -> None:
+    """Overwrite an orbit-number coordinate in place (test helper)."""
+    root = zarr.open_group(str(store), mode="r+", zarr_format=3, use_consolidated=False)
+    orbit_group = root[orbit]
+    assert isinstance(orbit_group, zarr.Group)
+    r10m = orbit_group["r10m"]
+    assert isinstance(r10m, zarr.Group)
+    arr = r10m[name]
+    assert isinstance(arr, zarr.Array)
+    arr.resize((len(values),))
+    arr[:] = np.array(values, dtype="int32")
+
+
+def test_zero_orbit_numbers_are_not_emitted(tmp_path: Path) -> None:
+    """`0` means "not recorded", and the sat extension forbids it.
+
+    Both coordinates are created with `fill_value=0` and the append resizes all three metadata
+    coordinates before writing them, so a torn append leaves a correctly-shaped slice holding 0 —
+    and there is a known upstream bug putting 0 on live slices. The sat v1.0.0 schema declares
+    both fields `{"type": "integer", "minimum": 1}`, so a 0 makes a validating STAC API reject
+    the item outright.
+    """
+    store = _make_s1_store(tmp_path, {"descending": [(T1_NS, "S1A"), (T2_NS, "S1A")]})
+    _set_orbit_coord(store, "descending", "relative_orbit", [0, 0])
+    _set_orbit_coord(store, "descending", "absolute_orbit", [0, 0])
+
+    item = build_s1_rtc_stac_item(str(store), "sentinel-1-grd-rtc-staging")
+
+    assert "sat:relative_orbit" not in item.properties
+    assert "sat:absolute_orbit" not in item.properties
+
+
+def test_orbit_number_needs_every_slice_recorded(tmp_path: Path) -> None:
+    """A single-valued sat field may not be claimed from a partial pool.
+
+    One unrecorded slice among otherwise-agreeing values must drop the field: the cube cannot
+    assert a track it has not observed for every acquisition.
+    """
+    store = _make_s1_store(tmp_path, {"descending": [(T1_NS, "S1A"), (T2_NS, "S1A")]})
+    _set_orbit_coord(store, "descending", "relative_orbit", [110, 0])
+
+    item = build_s1_rtc_stac_item(str(store), "sentinel-1-grd-rtc-staging")
+
+    assert "sat:relative_orbit" not in item.properties, (
+        "one unrecorded slice means the cube cannot claim a single track"
+    )

--- a/tests/test_s1_stac.py
+++ b/tests/test_s1_stac.py
@@ -458,8 +458,14 @@ def test_render_objects_carry_the_required_assets_field(tmp_path: Path) -> None:
     item_dict = item.to_dict(include_self_link=False)
 
     assert "renders" in item_dict, "render v1.0.0 requires `renders` at the item root"
-    assert "renders" not in item_dict["properties"], (
-        "`renders` under properties does not satisfy the render extension"
+    # `properties.renders` is a deliberate COMPATIBILITY MIRROR, not the location the extension
+    # reads: three data-pipeline consumers still fetch the old path, and one of them
+    # (`register_per_acquisition.py:132`) subscripts it directly, so dropping it outright would
+    # raise KeyError there the moment the data-model pin bumps. The root copy is authoritative;
+    # this asserts the mirror exists and cannot drift from it. Delete both the mirror and this
+    # assertion once those consumers read the root.
+    assert item_dict["properties"]["renders"] == item_dict["renders"], (
+        "the properties mirror must agree with the authoritative root `renders`"
     )
 
     for render in item_dict["renders"].values():

--- a/tests/test_s1_stac_per_acquisition.py
+++ b/tests/test_s1_stac_per_acquisition.py
@@ -338,6 +338,30 @@ def test_render_object_names_the_run_orbit_asset(tmp_path: Path) -> None:
     assert all(name in item.assets for name in rgb["assets"])
 
 
+def test_properties_render_mirror_carries_the_run_orbit_not_the_cube_preference(
+    tmp_path: Path,
+) -> None:
+    """The `properties.renders` compatibility mirror must be re-pointed per acquisition.
+
+    `props` is inherited from the cube base, whose render names the *preferred* orbit — ascending
+    when both are present. A per-acquisition item built for descending that copied the base's
+    mirror unchanged would carry the ascending render in `properties` and the descending one at
+    the root: the two disagree, and the consumers still reading `properties` (which is the entire
+    reason the mirror exists) would get the wrong orbit. That is the exact defect the mirror is
+    meant to prevent, reintroduced one level down.
+    """
+    store = _make_acq_cube(
+        tmp_path, {"ascending": [(T_EARLY, "S1A")], "descending": [(T_EARLY, "S1A")]}
+    )
+    item = build_s1_rtc_per_acquisition_items(store, orbit="descending", collection_id="acq")[0]
+    item_dict = item.to_dict(include_self_link=False)
+
+    assert item_dict["properties"]["renders"] == item_dict["renders"]
+    mirrored = item_dict["properties"]["renders"]["rgb"]
+    assert mirrored["assets"] == ["gamma0-rtc-backscatter-desc"]
+    assert mirrored["expression"].startswith("/descending:vv")
+
+
 def test_sat_orbit_numbers_are_per_slice(tmp_path: Path) -> None:
     """A per-acquisition item is single-valued by construction, so it carries BOTH orbit numbers —
     the absolute orbit that a multi-slice cube has to drop included."""

--- a/tests/test_s1_stac_per_acquisition.py
+++ b/tests/test_s1_stac_per_acquisition.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import datetime as dt
 import json
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -25,9 +25,6 @@ from eopf_geozarr.stac.s1_rtc import (
 )
 from eopf_geozarr.types import make_bounding_box, make_crs_code
 
-if TYPE_CHECKING:
-    from pathlib import Path
-
 CRS = make_crs_code("EPSG:32631")
 UTM_BBOX = make_bounding_box([300000.0, 4900000.0, 400000.0, 5000000.0])
 
@@ -35,6 +32,9 @@ UTM_BBOX = make_bounding_box([300000.0, 4900000.0, 400000.0, 5000000.0])
 # datetime follows its own slice, not its list position.
 T_LATER = int(dt.datetime(2026, 6, 7, 5, 52, 48, tzinfo=dt.UTC).timestamp() * 1e9)
 T_EARLY = int(dt.datetime(2026, 6, 5, 6, 9, 7, tzinfo=dt.UTC).timestamp() * 1e9)
+
+# (first absolute orbit, relative orbit) per orbit direction, written by ``_make_acq_cube``.
+_ORBIT_NUMBERS = {"ascending": (58011, 37), "descending": (57050, 110)}
 
 
 # =============================================================================
@@ -136,6 +136,8 @@ def test_slice_coverages_times_are_utc_datetimes(tmp_path: Path) -> None:
 
 
 def test_slice_coverages_skips_missing_orbit(tmp_path: Path) -> None:
+    # The store name is descriptive, not a real cube name: `slice_coverages` reads coverage only and
+    # never derives a tile id from it, so it is not subject to the MGRS validation the builders do.
     store = str(tmp_path / "s1-rtc-asc-only.zarr")
     root = zarr.open_group(store, mode="w", zarr_format=3)
     _write_r720m(root, "ascending", [np.ones((4, 4))], [7])
@@ -148,9 +150,16 @@ def test_slice_coverages_skips_missing_orbit(tmp_path: Path) -> None:
 
 
 def _make_acq_cube(
-    tmp_path: Path, orbits: dict[str, list[tuple[int, str]]], tile_id: str = "31TCH"
+    tmp_path: Path,
+    orbits: dict[str, list[tuple[int, str]]],
+    tile_id: str = "31TCH",
+    orbit_numbers: bool = True,
 ) -> str:
-    """A cube with r10m time/platform (+ tiny data arrays) per orbit — enough to build per-acq items."""
+    """A cube with r10m time/platform (+ tiny data arrays) per orbit — enough to build per-acq items.
+
+    ``orbit_numbers=False`` omits the int32 absolute/relative orbit coordinates, mirroring a store
+    written before ``s1_ingest`` recorded them.
+    """
     store = str(tmp_path / f"s1-rtc-{tile_id}.zarr")
     root = zarr.open_group(store, mode="w", zarr_format=3)
     ny = nx = 4
@@ -171,6 +180,16 @@ def _make_acq_cube(
         r10m.create_array("platform", shape=platforms.shape, dtype="<U4", chunks=(512,))[:] = (
             platforms
         )
+        if orbit_numbers:
+            # int32 `time` coords as s1_ingest.py writes them: a track per orbit direction, and an
+            # absolute orbit unique per acquisition.
+            base_abs, rel = _ORBIT_NUMBERS[orbit]
+            r10m.create_array("absolute_orbit", shape=(nt,), dtype="int32", chunks=(512,))[:] = (
+                np.array([base_abs + i for i in range(nt)], dtype="int32")
+            )
+            r10m.create_array("relative_orbit", shape=(nt,), dtype="int32", chunks=(512,))[:] = (
+                np.full(nt, rel, dtype="int32")
+            )
         for name, dtype in (("vv", "float32"), ("vh", "float32"), ("border_mask", "uint8")):
             r10m.create_array(name, shape=(nt, ny, nx), dtype=dtype, chunks=(1, ny, nx))[:] = 0
     zarr.consolidate_metadata(store, zarr_format=3)
@@ -215,7 +234,9 @@ def test_reorients_orbit_metadata_and_keeps_only_run_orbit_asset(tmp_path: Path)
     assert item.properties["sat:orbit_state"] == "descending"
     # SAT ext must be declared even though the dual-orbit cube base omitted it.
     assert "https://stac-extensions.github.io/sat/v1.0.0/schema.json" in item.stac_extensions
-    assert item.properties["renders"]["rgb"]["expression"].startswith("/descending:vv")
+    assert item.to_dict(include_self_link=False)["renders"]["rgb"]["expression"].startswith(
+        "/descending:vv"
+    )
     assert "gamma0-rtc-backscatter-desc" in item.assets
     assert "gamma0-rtc-backscatter-asc" not in item.assets
     assert "border-mask-asc" not in item.assets
@@ -224,14 +245,18 @@ def test_reorients_orbit_metadata_and_keeps_only_run_orbit_asset(tmp_path: Path)
 
 def test_per_slice_platform_and_no_datacube(tmp_path: Path) -> None:
     """Each item gets its own slice's platform (normalized to the STAC convention); a single
-    acquisition is not a datacube, and `created` is not set."""
+    acquisition is not a datacube.
+
+    `created` used to be asserted absent here; the collection requires it, and it is inherited from
+    the cube base as the metadata build time (STAC Common Metadata, not the timestamps extension).
+    """
     store = _make_acq_cube(tmp_path, {"descending": [(T_LATER, "s1a"), (T_EARLY, "s1c")]})
     items = build_s1_rtc_per_acquisition_items(store, orbit="descending", collection_id="acq")
     assert [i.properties["platform"] for i in items] == ["sentinel-1a", "sentinel-1c"]
     for item in items:
         assert "cube:dimensions" not in item.properties
         assert DATACUBE_EXT not in item.stac_extensions
-        assert "created" not in item.properties
+        assert dt.datetime.fromisoformat(item.properties["created"])
 
 
 def test_grid_code_inherited_from_cube(tmp_path: Path) -> None:
@@ -294,3 +319,106 @@ def test_datetime_follows_slice_not_physical_position(tmp_path: Path) -> None:
     assert items[0].properties["datetime"] == "2026-06-07T05:52:48+00:00"
     assert items[1].properties["datetime"] == "2026-06-05T06:09:07+00:00"
     assert items[0].id == "s1-rtc-31TCH-20260607t055248"
+
+
+def test_render_object_names_the_run_orbit_asset(tmp_path: Path) -> None:
+    """`assets` is the one REQUIRED field of a Render Object (render v1.0.0), and on a per-acq item
+    it must name the run orbit's γ⁰ asset — the only γ⁰ asset the item still has.
+
+    Without it every emitted item failed the render extension it declared, so `stac-validator` (and
+    a validating STAC API) rejected it.
+    """
+    store = _make_acq_cube(
+        tmp_path, {"ascending": [(T_EARLY, "S1A")], "descending": [(T_EARLY, "S1A")]}
+    )
+    item = build_s1_rtc_per_acquisition_items(store, orbit="descending", collection_id="acq")[0]
+
+    rgb = item.to_dict(include_self_link=False)["renders"]["rgb"]
+    assert rgb["assets"] == ["gamma0-rtc-backscatter-desc"]
+    assert all(name in item.assets for name in rgb["assets"])
+
+
+def test_sat_orbit_numbers_are_per_slice(tmp_path: Path) -> None:
+    """A per-acquisition item is single-valued by construction, so it carries BOTH orbit numbers —
+    the absolute orbit that a multi-slice cube has to drop included."""
+    store = _make_acq_cube(tmp_path, {"descending": [(T_LATER, "S1A"), (T_EARLY, "S1A")]})
+    items = build_s1_rtc_per_acquisition_items(store, orbit="descending", collection_id="acq")
+
+    assert [i.properties["sat:absolute_orbit"] for i in items] == [57050, 57051]
+    assert [i.properties["sat:relative_orbit"] for i in items] == [110, 110]
+    assert all(
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json" in i.stac_extensions
+        for i in items
+    )
+
+
+def test_sat_orbit_numbers_absent_when_the_store_has_none(tmp_path: Path) -> None:
+    """A pre-#216 store without the orbit coordinates must still build items, without the fields."""
+    store = _make_acq_cube(tmp_path, {"descending": [(T_EARLY, "S1A")]}, orbit_numbers=False)
+    item = build_s1_rtc_per_acquisition_items(store, orbit="descending", collection_id="acq")[0]
+
+    assert "sat:absolute_orbit" not in item.properties
+    assert "sat:relative_orbit" not in item.properties
+    assert item.properties["sat:orbit_state"] == "descending"  # still single-orbit by construction
+
+
+def test_sat_orbit_numbers_do_not_leak_from_the_other_orbit(tmp_path: Path) -> None:
+    """The cube base's single-valued sat:*_orbit must never survive onto an orbit that records none.
+
+    Only the ascending group carries orbit coordinates here, so the base cube emits its values; the
+    descending items must drop them rather than inherit another track's orbit numbers.
+    """
+    store = str(tmp_path / "s1-rtc-31TCH.zarr")
+    root = zarr.open_group(store, mode="w", zarr_format=3)
+    ny = nx = 4
+    for orbit in ("ascending", "descending"):
+        og = root.create_group(orbit)
+        og.attrs.update({"proj:code": CRS, "spatial:bbox": UTM_BBOX})
+        r10m = og.create_group("r10m")
+        r10m.create_array("time", shape=(1,), dtype="int64", chunks=(512,))[:] = [T_EARLY]
+        r10m.create_array("platform", shape=(1,), dtype="<U4", chunks=(512,))[:] = ["S1A"]
+        if orbit == "ascending":
+            r10m.create_array("absolute_orbit", shape=(1,), dtype="int32", chunks=(512,))[:] = [
+                58011
+            ]
+            r10m.create_array("relative_orbit", shape=(1,), dtype="int32", chunks=(512,))[:] = [37]
+        for name, dtype in (("vv", "float32"), ("vh", "float32"), ("border_mask", "uint8")):
+            r10m.create_array(name, shape=(1, ny, nx), dtype=dtype, chunks=(1, ny, nx))[:] = 0
+    zarr.consolidate_metadata(store, zarr_format=3)
+
+    desc = build_s1_rtc_per_acquisition_items(store, orbit="descending", collection_id="acq")[0]
+    assert "sat:absolute_orbit" not in desc.properties
+    assert "sat:relative_orbit" not in desc.properties
+
+    asc = build_s1_rtc_per_acquisition_items(store, orbit="ascending", collection_id="acq")[0]
+    assert asc.properties["sat:absolute_orbit"] == 58011
+
+
+def test_each_item_gets_its_own_providers_block(tmp_path: Path) -> None:
+    """Attribution is copied down from the collection onto every item (a STAC API search returns
+    items without their collection), and each item owns its objects rather than sharing the cube's.
+    """
+    store = _make_acq_cube(tmp_path, {"descending": [(T_LATER, "S1A"), (T_EARLY, "S1A")]})
+    items = build_s1_rtc_per_acquisition_items(store, orbit="descending", collection_id="acq")
+
+    for item in items:
+        assert {p["name"] for p in item.properties["providers"]} == {
+            "European Commission",
+            "ESA",
+            "EOPF Sentinel Zarr Samples Service",
+        }
+    # Distinct objects: editing one item's providers must not rewrite its siblings'.
+    first, second = (i.properties["providers"] for i in items)
+    assert first is not second
+    assert first[0] is not second[0]
+
+
+def test_malformed_store_name_raises_before_any_item_is_built(tmp_path: Path) -> None:
+    """The per-acquisition builder derives the same tile id, so it must reject the same names —
+    otherwise it mints ids like `s1-rtc-cube-20260605t060907` with a `MGRS-cube` grid code."""
+    store = _make_acq_cube(tmp_path, {"descending": [(T_EARLY, "S1A")]})
+    renamed = Path(store).with_name("cube.zarr")
+    Path(store).rename(renamed)
+
+    with pytest.raises(ValueError, match="MGRS tile id"):
+        build_s1_rtc_per_acquisition_items(str(renamed), orbit="descending", collection_id="acq")


### PR DESCRIPTION
Stacked on #216 — targets `s1-tiling`, not `main`, so this diff reviews on its own.

Fixes two production defects in the S1 RTC catalogue path. `S1RtcRoot.from_zarr` rejected every store this repo's own writer produces (23 `extra_forbidden` errors: the fixture it validated against predated the `x`/`y`/`spatial_ref` coordinates and the per-level `time` added in #192). And every emitted STAC item failed the render extension it declared — `renders` sat under `properties` rather than the item root, and Render Objects omitted their one required field, `assets`. Also: malformed store names now raise instead of minting a bad `grid:code`, `sat:*_orbit == 0` reads as "not recorded" rather than tripping the extension's `minimum: 1`, and `_utm_to_wgs84` densifies so a UTM zone 1/60 tile gets a 1.75° antimeridian-crossing bbox instead of a 358° one spanning the globe.

## For reviewers

**`renders` is emitted twice, deliberately.** The item root is authoritative (what render v1.0.0 requires); the copy under `properties` is a temporary compatibility mirror, because three data-pipeline consumers still read the old location and `register_per_acquisition.py:132` subscripts it directly — it would raise `KeyError` the moment the data-model pin bumps. Both code sites carry a `COMPATIBILITY MIRROR` comment naming all three; remove the mirror once they read the root.

**Not pinned by a test:** `jsonschema` is in no dependency group, so the render/sat schema claims were verified by running `stac-validator` by hand.

## Author attestation

- [x] I am a human, these are my changes, and I have reviewed and understood every change and can explain why each is correct.

AI-assisted: implementation and review with Claude Code, including an adversarial review pass that found three of the defects fixed here. Reviewed commit by commit.
