### PR TITLE
fix(s2): write geo metadata for conditions/mask groups so SCL is readable

### DIFF
--- a/src/eopf_geozarr/data_api/geozarr/common.py
+++ b/src/eopf_geozarr/data_api/geozarr/common.py
@@ -6,6 +6,7 @@ import io
 import urllib
 import urllib.request
 from dataclasses import dataclass
+from http.client import HTTPException
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -131,7 +132,9 @@ CF_STANDARD_NAME_URL = (
 try:
     CF_STANDARD_NAMES = get_cf_standard_names(url=CF_STANDARD_NAME_URL)
     DO_CF_NAME_VALIDATION = True
-except URLError:
+except (URLError, HTTPException, OSError):
+    # A truncated response raises IncompleteRead, not URLError, and this runs at
+    # import time — an unhandled one makes `import eopf_geozarr` fail outright.
     CF_STANDARD_NAMES = ()
     DO_CF_NAME_VALIDATION = False
 

--- a/src/eopf_geozarr/data_api/geozarr/common.py
+++ b/src/eopf_geozarr/data_api/geozarr/common.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import io
 import urllib
 import urllib.request
+import warnings
 from dataclasses import dataclass
 from http.client import HTTPException
 from typing import (
@@ -18,7 +19,6 @@ from typing import (
     TypeGuard,
     TypeVar,
 )
-from urllib.error import URLError
 
 from cf_xarray.utils import parse_cf_standard_name_table
 from pydantic import AfterValidator, BaseModel, Field, model_validator
@@ -132,9 +132,23 @@ CF_STANDARD_NAME_URL = (
 try:
     CF_STANDARD_NAMES = get_cf_standard_names(url=CF_STANDARD_NAME_URL)
     DO_CF_NAME_VALIDATION = True
-except (URLError, HTTPException, OSError):
-    # A truncated response raises IncompleteRead, not URLError, and this runs at
-    # import time — an unhandled one makes `import eopf_geozarr` fail outright.
+except (OSError, HTTPException) as _cf_exc:
+    # This runs at import time, so an uncaught failure here breaks `import eopf_geozarr` for every
+    # mission. A truncated response raises http.client.IncompleteRead, which is an HTTPException
+    # and not a URLError; URLError, TimeoutError, ConnectionResetError and ssl.SSLError are all
+    # OSError subclasses. CF name validation is an optional check: degrade to "off", never to a
+    # crash. (A cleanly truncated body still raises ElementTree.ParseError, which is neither -- see
+    # issue #265.)
+    #
+    # Warn rather than degrade silently. With validation off, `check_standard_name` accepts
+    # anything, so a caller that believes it is validating is not -- the failure has to be visible
+    # in the log or it will be mistaken for a passing check.
+    warnings.warn(
+        f"Could not fetch the CF standard name table ({type(_cf_exc).__name__}: {_cf_exc}); "
+        "CF standard-name validation is DISABLED for this process.",
+        RuntimeWarning,
+        stacklevel=2,
+    )
     CF_STANDARD_NAMES = ()
     DO_CF_NAME_VALIDATION = False
 

--- a/src/eopf_geozarr/s2_optimization/s2_multiscale.py
+++ b/src/eopf_geozarr/s2_optimization/s2_multiscale.py
@@ -63,6 +63,13 @@ def get_grid_spacing(ds: xr.DataArray, coords: tuple[Hashable, ...]) -> tuple[fl
     return tuple(np.abs(ds.coords[coord][0].data - ds.coords[coord][1].data) for coord in coords)
 
 
+def _half_pixel(coords: np.ndarray) -> float:
+    """Half the grid spacing of a coordinate array, or 0.0 when it has no spacing."""
+    if len(coords) < 2:
+        return 0.0
+    return float(np.abs(coords[1] - coords[0])) / 2
+
+
 def _transform_from_coordinates(
     dataset: xr.Dataset,
 ) -> tuple[float, float, float, float, float, float] | None:
@@ -77,8 +84,11 @@ def _transform_from_coordinates(
 
     pixel_size_x = float(np.abs(x_coords[1] - x_coords[0]))
     pixel_size_y = float(np.abs(y_coords[1] - y_coords[0]))
-    x_min = float(x_coords.min())
-    y_max = float(y_coords.max())
+    # Coordinates label pixel centres, but an affine transform maps pixel *edges*,
+    # so the origin sits half a pixel outside the first centre. Without this the
+    # transform can never agree with rioxarray's and is half a cell off.
+    x_min = float(x_coords.min()) - pixel_size_x / 2
+    y_max = float(y_coords.max()) + pixel_size_y / 2
     return (pixel_size_x, 0.0, x_min, 0.0, -pixel_size_y, y_max)
 
 
@@ -1050,7 +1060,8 @@ def stream_write_dataset(
 
     Args:
         dataset: Dataset to write
-        dataset_path: Output path for dataset
+        path: Group path to write the dataset to
+        group: Destination zarr group
         encoding: Encoding dictionary for variables
         enable_sharding: Enable Zarr v3 sharding
         crs: Coordinate Reference System for geographic metadata
@@ -1080,11 +1091,13 @@ def stream_write_dataset(
     # Rechunk dataset to align with encoding
     dataset = rechunk_dataset_for_encoding(dataset, encoding)
 
-    # Add the geo metadata before writing for
-    # - /measurements/ groups
-    # - /quality/ groups
-    if "/measurements/" in path or "/quality/" in path:
+    # Add the geo metadata before writing for the groups on a projected grid
+    if needs_geo_metadata(dataset):
         write_geo_metadata(dataset, crs=crs)
+        # `spatial_ref` did not exist when the encoding was built; write it like the
+        # sibling coordinates rather than falling back to xarray's compressed default.
+        if "spatial_ref" in dataset.coords and "spatial_ref" not in encoding:
+            encoding["spatial_ref"] = {"compressors": None}
 
     # Sanitize NaN values in dataset attributes before writing
     dataset = sanitize_dataset_attributes(dataset)
@@ -1140,6 +1153,23 @@ def stream_write_dataset(
     return dataset
 
 
+def needs_geo_metadata(dataset: xr.Dataset) -> bool:
+    """
+    Whether a group is on the product's projected grid and should carry geo metadata.
+
+    Decided from the data itself rather than from a list of group names: a group
+    gridded on x/y is in the product CRS, while /conditions/meteorology is on
+    latitude/longitude and must not be stamped with it.
+
+    Args:
+        dataset: Dataset about to be written
+
+    Returns:
+        True if geographic metadata should be written for this group
+    """
+    return {"x", "y"} <= set(dataset.dims)
+
+
 def write_geo_metadata(
     dataset: xr.Dataset,
     grid_mapping_var_name: str = "spatial_ref",
@@ -1189,8 +1219,14 @@ def write_geo_metadata(
         if "x" in dataset.coords and "y" in dataset.coords:
             x_coords = dataset.coords["x"].values
             y_coords = dataset.coords["y"].values
-            x_min, x_max = float(x_coords.min()), float(x_coords.max())
-            y_min, y_max = float(y_coords.min()), float(y_coords.max())
+            # `spatial:registration` below declares "pixel", so the bbox covers the
+            # pixel edges. Coordinates are centres, hence the half-pixel outset —
+            # without it the footprint is a half-pixel narrower than the raster and
+            # disagrees with the arrays' own `proj:bbox`.
+            half_x = _half_pixel(x_coords)
+            half_y = _half_pixel(y_coords)
+            x_min, x_max = float(x_coords.min()) - half_x, float(x_coords.max()) + half_x
+            y_min, y_max = float(y_coords.min()) - half_y, float(y_coords.max()) + half_y
             spatial_data["spatial:bbox"] = [x_min, y_min, x_max, y_max]
 
             spatial_transform = _preferred_spatial_transform(dataset)
@@ -1199,12 +1235,13 @@ def write_geo_metadata(
             if spatial_transform is not None and not all(t == 0 for t in spatial_transform):
                 spatial_data["spatial:transform"] = list(spatial_transform)
 
-            # Add spatial shape if data variables exist
-            if dataset.data_vars:
-                first_var = next(iter(dataset.data_vars.values()))
-                if first_var.ndim >= 2:
-                    height, width = first_var.shape[-2:]
-                    spatial_data["spatial:shape"] = [height, width]
+            # Shape comes from the raster dims themselves: the first data variable
+            # need not be 2-D, nor have (y, x) as its trailing dims.
+            if "y" in dataset.sizes and "x" in dataset.sizes:
+                spatial_data["spatial:shape"] = [
+                    int(dataset.sizes["y"]),
+                    int(dataset.sizes["x"]),
+                ]
 
         # Build validated spatial + proj convention attrs (data + CMOs) via zarr-cm
         dataset.attrs.update(utils.build_convention_attrs(spatial=spatial_data, crs=crs))

--- a/tests/_test_data/geozarr_examples/S2A_MSIL2A_20251008T100041_N0511_R122_T32TQM_20251008T122613.json
+++ b/tests/_test_data/geozarr_examples/S2A_MSIL2A_20251008T100041_N0511_R122_T32TQM_20251008T122613.json
@@ -35,7 +35,41 @@
         "geometry": {
           "zarr_format": 3,
           "node_type": "group",
-          "attributes": {},
+          "attributes": {
+            "grid_mapping": "spatial_ref",
+            "spatial:dimensions": [
+              "y",
+              "x"
+            ],
+            "spatial:registration": "pixel",
+            "spatial:bbox": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "spatial:shape": [
+              23,
+              23
+            ],
+            "zarr_conventions": [
+              {
+                "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                "name": "spatial:",
+                "description": "Spatial coordinate information"
+              },
+              {
+                "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                "name": "proj:",
+                "description": "Coordinate reference system information for geospatial data"
+              }
+            ],
+            "proj:code": "EPSG:32632"
+          },
           "members": {
             "angle": {
               "zarr_format": 3,
@@ -160,6 +194,7 @@
               "node_type": "array",
               "attributes": {
                 "unit": "deg",
+                "grid_mapping": "spatial_ref",
                 "_FillValue": "AAAAAAAA+H8="
               },
               "shape": [
@@ -209,6 +244,7 @@
               "node_type": "array",
               "attributes": {
                 "unit": "deg",
+                "grid_mapping": "spatial_ref",
                 "_FillValue": "AAAAAAAA+H8="
               },
               "shape": [
@@ -256,10 +292,59 @@
                 "angle"
               ]
             },
+            "spatial_ref": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]",
+                "semi_major_axis": 6378137.0,
+                "semi_minor_axis": 6356752.314245179,
+                "inverse_flattening": 298.257223563,
+                "reference_ellipsoid_name": "WGS 84",
+                "longitude_of_prime_meridian": 0.0,
+                "prime_meridian_name": "Greenwich",
+                "geographic_crs_name": "WGS 84",
+                "horizontal_datum_name": "World Geodetic System 1984",
+                "projected_crs_name": "WGS 84 / UTM zone 32N",
+                "grid_mapping_name": "transverse_mercator",
+                "latitude_of_projection_origin": 0.0,
+                "longitude_of_central_meridian": 9.0,
+                "false_easting": 500000.0,
+                "false_northing": 0.0,
+                "scale_factor_at_central_meridian": 0.9996,
+                "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]"
+              },
+              "shape": [],
+              "data_type": "int64",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": []
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": 0,
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": null
+            },
             "sun_angles": {
               "zarr_format": 3,
               "node_type": "array",
               "attributes": {
+                "grid_mapping": "spatial_ref",
                 "_FillValue": "AAAAAAAA+H8="
               },
               "shape": [
@@ -314,6 +399,7 @@
               "zarr_format": 3,
               "node_type": "array",
               "attributes": {
+                "grid_mapping": "spatial_ref",
                 "_FillValue": "AAAAAAAA+H8="
               },
               "shape": [
@@ -457,7 +543,41 @@
                 "r10m": {
                   "zarr_format": 3,
                   "node_type": "group",
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:shape": [
+                      10980,
+                      10980
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "name": "spatial:",
+                        "description": "Spatial coordinate information"
+                      },
+                      {
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "name": "proj:",
+                        "description": "Coordinate reference system information for geospatial data"
+                      }
+                    ],
+                    "proj:code": "EPSG:32632"
+                  },
                   "members": {
                     "b02": {
                       "zarr_format": 3,
@@ -486,7 +606,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         10980,
@@ -557,7 +678,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         10980,
@@ -628,7 +750,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         10980,
@@ -699,7 +822,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         10980,
@@ -742,6 +866,54 @@
                         "y",
                         "x"
                       ]
+                    },
+                    "spatial_ref": {
+                      "zarr_format": 3,
+                      "node_type": "array",
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]",
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "inverse_flattening": 298.257223563,
+                        "reference_ellipsoid_name": "WGS 84",
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "geographic_crs_name": "WGS 84",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "projected_crs_name": "WGS 84 / UTM zone 32N",
+                        "grid_mapping_name": "transverse_mercator",
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": 9.0,
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]"
+                      },
+                      "shape": [],
+                      "data_type": "int64",
+                      "chunk_grid": {
+                        "name": "regular",
+                        "configuration": {
+                          "chunk_shape": []
+                        }
+                      },
+                      "chunk_key_encoding": {
+                        "name": "default",
+                        "configuration": {
+                          "separator": "/"
+                        }
+                      },
+                      "fill_value": 0,
+                      "codecs": [
+                        {
+                          "name": "bytes",
+                          "configuration": {
+                            "endian": "little"
+                          }
+                        }
+                      ],
+                      "storage_transformers": [],
+                      "dimension_names": null
                     },
                     "x": {
                       "zarr_format": 3,
@@ -820,7 +992,41 @@
                 "r20m": {
                   "zarr_format": 3,
                   "node_type": "group",
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:shape": [
+                      5490,
+                      5490
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "name": "spatial:",
+                        "description": "Spatial coordinate information"
+                      },
+                      {
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "name": "proj:",
+                        "description": "Coordinate reference system information for geospatial data"
+                      }
+                    ],
+                    "proj:code": "EPSG:32632"
+                  },
                   "members": {
                     "b05": {
                       "zarr_format": 3,
@@ -849,7 +1055,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         5490,
@@ -920,7 +1127,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         5490,
@@ -991,7 +1199,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         5490,
@@ -1062,7 +1271,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         5490,
@@ -1133,7 +1343,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         5490,
@@ -1204,7 +1415,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         5490,
@@ -1247,6 +1459,54 @@
                         "y",
                         "x"
                       ]
+                    },
+                    "spatial_ref": {
+                      "zarr_format": 3,
+                      "node_type": "array",
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]",
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "inverse_flattening": 298.257223563,
+                        "reference_ellipsoid_name": "WGS 84",
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "geographic_crs_name": "WGS 84",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "projected_crs_name": "WGS 84 / UTM zone 32N",
+                        "grid_mapping_name": "transverse_mercator",
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": 9.0,
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]"
+                      },
+                      "shape": [],
+                      "data_type": "int64",
+                      "chunk_grid": {
+                        "name": "regular",
+                        "configuration": {
+                          "chunk_shape": []
+                        }
+                      },
+                      "chunk_key_encoding": {
+                        "name": "default",
+                        "configuration": {
+                          "separator": "/"
+                        }
+                      },
+                      "fill_value": 0,
+                      "codecs": [
+                        {
+                          "name": "bytes",
+                          "configuration": {
+                            "endian": "little"
+                          }
+                        }
+                      ],
+                      "storage_transformers": [],
+                      "dimension_names": null
                     },
                     "x": {
                       "zarr_format": 3,
@@ -1325,7 +1585,41 @@
                 "r60m": {
                   "zarr_format": 3,
                   "node_type": "group",
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:shape": [
+                      1830,
+                      1830
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "name": "spatial:",
+                        "description": "Spatial coordinate information"
+                      },
+                      {
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "name": "proj:",
+                        "description": "Coordinate reference system information for geospatial data"
+                      }
+                    ],
+                    "proj:code": "EPSG:32632"
+                  },
                   "members": {
                     "b01": {
                       "zarr_format": 3,
@@ -1354,7 +1648,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         1830,
@@ -1425,7 +1720,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         1830,
@@ -1496,7 +1792,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         1830,
@@ -1539,6 +1836,54 @@
                         "y",
                         "x"
                       ]
+                    },
+                    "spatial_ref": {
+                      "zarr_format": 3,
+                      "node_type": "array",
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]",
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "inverse_flattening": 298.257223563,
+                        "reference_ellipsoid_name": "WGS 84",
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "geographic_crs_name": "WGS 84",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "projected_crs_name": "WGS 84 / UTM zone 32N",
+                        "grid_mapping_name": "transverse_mercator",
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": 9.0,
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]"
+                      },
+                      "shape": [],
+                      "data_type": "int64",
+                      "chunk_grid": {
+                        "name": "regular",
+                        "configuration": {
+                          "chunk_shape": []
+                        }
+                      },
+                      "chunk_key_encoding": {
+                        "name": "default",
+                        "configuration": {
+                          "separator": "/"
+                        }
+                      },
+                      "fill_value": 0,
+                      "codecs": [
+                        {
+                          "name": "bytes",
+                          "configuration": {
+                            "endian": "little"
+                          }
+                        }
+                      ],
+                      "storage_transformers": [],
+                      "dimension_names": null
                     },
                     "x": {
                       "zarr_format": 3,
@@ -1624,7 +1969,41 @@
                 "r60m": {
                   "zarr_format": 3,
                   "node_type": "group",
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:shape": [
+                      1830,
+                      1830
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "name": "spatial:",
+                        "description": "Spatial coordinate information"
+                      },
+                      {
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "name": "proj:",
+                        "description": "Coordinate reference system information for geospatial data"
+                      }
+                    ],
+                    "proj:code": "EPSG:32632"
+                  },
                   "members": {
                     "b00": {
                       "zarr_format": 3,
@@ -1663,7 +2042,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         1830,
@@ -1706,6 +2086,54 @@
                         "y",
                         "x"
                       ]
+                    },
+                    "spatial_ref": {
+                      "zarr_format": 3,
+                      "node_type": "array",
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]",
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "inverse_flattening": 298.257223563,
+                        "reference_ellipsoid_name": "WGS 84",
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "geographic_crs_name": "WGS 84",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "projected_crs_name": "WGS 84 / UTM zone 32N",
+                        "grid_mapping_name": "transverse_mercator",
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": 9.0,
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]"
+                      },
+                      "shape": [],
+                      "data_type": "int64",
+                      "chunk_grid": {
+                        "name": "regular",
+                        "configuration": {
+                          "chunk_shape": []
+                        }
+                      },
+                      "chunk_key_encoding": {
+                        "name": "default",
+                        "configuration": {
+                          "separator": "/"
+                        }
+                      },
+                      "fill_value": 0,
+                      "codecs": [
+                        {
+                          "name": "bytes",
+                          "configuration": {
+                            "endian": "little"
+                          }
+                        }
+                      ],
+                      "storage_transformers": [],
+                      "dimension_names": null
                     },
                     "x": {
                       "zarr_format": 3,
@@ -1791,7 +2219,41 @@
                 "r20m": {
                   "zarr_format": 3,
                   "node_type": "group",
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:shape": [
+                      5490,
+                      5490
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "name": "spatial:",
+                        "description": "Spatial coordinate information"
+                      },
+                      {
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "name": "proj:",
+                        "description": "Coordinate reference system information for geospatial data"
+                      }
+                    ],
+                    "proj:code": "EPSG:32632"
+                  },
                   "members": {
                     "scl": {
                       "zarr_format": 3,
@@ -1818,7 +2280,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         5490,
@@ -1861,6 +2324,54 @@
                         "y",
                         "x"
                       ]
+                    },
+                    "spatial_ref": {
+                      "zarr_format": 3,
+                      "node_type": "array",
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]",
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "inverse_flattening": 298.257223563,
+                        "reference_ellipsoid_name": "WGS 84",
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "geographic_crs_name": "WGS 84",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "projected_crs_name": "WGS 84 / UTM zone 32N",
+                        "grid_mapping_name": "transverse_mercator",
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": 9.0,
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]"
+                      },
+                      "shape": [],
+                      "data_type": "int64",
+                      "chunk_grid": {
+                        "name": "regular",
+                        "configuration": {
+                          "chunk_shape": []
+                        }
+                      },
+                      "chunk_key_encoding": {
+                        "name": "default",
+                        "configuration": {
+                          "separator": "/"
+                        }
+                      },
+                      "fill_value": 0,
+                      "codecs": [
+                        {
+                          "name": "bytes",
+                          "configuration": {
+                            "endian": "little"
+                          }
+                        }
+                      ],
+                      "storage_transformers": [],
+                      "dimension_names": null
                     },
                     "x": {
                       "zarr_format": 3,
@@ -1939,7 +2450,41 @@
                 "r60m": {
                   "zarr_format": 3,
                   "node_type": "group",
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:shape": [
+                      1830,
+                      1830
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "name": "spatial:",
+                        "description": "Spatial coordinate information"
+                      },
+                      {
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "name": "proj:",
+                        "description": "Coordinate reference system information for geospatial data"
+                      }
+                    ],
+                    "proj:code": "EPSG:32632"
+                  },
                   "members": {
                     "scl": {
                       "zarr_format": 3,
@@ -1966,7 +2511,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         1830,
@@ -2009,6 +2555,54 @@
                         "y",
                         "x"
                       ]
+                    },
+                    "spatial_ref": {
+                      "zarr_format": 3,
+                      "node_type": "array",
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]",
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "inverse_flattening": 298.257223563,
+                        "reference_ellipsoid_name": "WGS 84",
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "geographic_crs_name": "WGS 84",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "projected_crs_name": "WGS 84 / UTM zone 32N",
+                        "grid_mapping_name": "transverse_mercator",
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": 9.0,
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]"
+                      },
+                      "shape": [],
+                      "data_type": "int64",
+                      "chunk_grid": {
+                        "name": "regular",
+                        "configuration": {
+                          "chunk_shape": []
+                        }
+                      },
+                      "chunk_key_encoding": {
+                        "name": "default",
+                        "configuration": {
+                          "separator": "/"
+                        }
+                      },
+                      "fill_value": 0,
+                      "codecs": [
+                        {
+                          "name": "bytes",
+                          "configuration": {
+                            "endian": "little"
+                          }
+                        }
+                      ],
+                      "storage_transformers": [],
+                      "dimension_names": null
                     },
                     "x": {
                       "zarr_format": 3,
@@ -4269,13 +4863,6 @@
                       "configuration": {
                         "endian": "little"
                       }
-                    },
-                    {
-                      "name": "zstd",
-                      "configuration": {
-                        "level": 0,
-                        "checksum": false
-                      }
                     }
                   ],
                   "storage_transformers": [],
@@ -6349,13 +6936,6 @@
                       "name": "bytes",
                       "configuration": {
                         "endian": "little"
-                      }
-                    },
-                    {
-                      "name": "zstd",
-                      "configuration": {
-                        "level": 0,
-                        "checksum": false
                       }
                     }
                   ],
@@ -8507,13 +9087,6 @@
                       "configuration": {
                         "endian": "little"
                       }
-                    },
-                    {
-                      "name": "zstd",
-                      "configuration": {
-                        "level": 0,
-                        "checksum": false
-                      }
                     }
                   ],
                   "storage_transformers": [],
@@ -9839,13 +10412,6 @@
                       "configuration": {
                         "endian": "little"
                       }
-                    },
-                    {
-                      "name": "zstd",
-                      "configuration": {
-                        "level": 0,
-                        "checksum": false
-                      }
                     }
                   ],
                   "storage_transformers": [],
@@ -10153,13 +10719,6 @@
                       "configuration": {
                         "endian": "little"
                       }
-                    },
-                    {
-                      "name": "zstd",
-                      "configuration": {
-                        "level": 0,
-                        "checksum": false
-                      }
                     }
                   ],
                   "storage_transformers": [],
@@ -10466,13 +11025,6 @@
                       "name": "bytes",
                       "configuration": {
                         "endian": "little"
-                      }
-                    },
-                    {
-                      "name": "zstd",
-                      "configuration": {
-                        "level": 0,
-                        "checksum": false
                       }
                     }
                   ],
@@ -11082,13 +11634,6 @@
                       "name": "bytes",
                       "configuration": {
                         "endian": "little"
-                      }
-                    },
-                    {
-                      "name": "zstd",
-                      "configuration": {
-                        "level": 0,
-                        "checksum": false
                       }
                     }
                   ],
@@ -11803,13 +12348,6 @@
                       "configuration": {
                         "endian": "little"
                       }
-                    },
-                    {
-                      "name": "zstd",
-                      "configuration": {
-                        "level": 0,
-                        "checksum": false
-                      }
                     }
                   ],
                   "storage_transformers": [],
@@ -12247,13 +12785,6 @@
                       "configuration": {
                         "endian": "little"
                       }
-                    },
-                    {
-                      "name": "zstd",
-                      "configuration": {
-                        "level": 0,
-                        "checksum": false
-                      }
                     }
                   ],
                   "storage_transformers": [],
@@ -12563,13 +13094,6 @@
                       "name": "bytes",
                       "configuration": {
                         "endian": "little"
-                      }
-                    },
-                    {
-                      "name": "zstd",
-                      "configuration": {
-                        "level": 0,
-                        "checksum": false
                       }
                     }
                   ],

--- a/tests/_test_data/geozarr_examples/S2B_MSIL1C_20250113T103309_N0511_R108_T32TLQ_20250113T122458.json
+++ b/tests/_test_data/geozarr_examples/S2B_MSIL1C_20250113T103309_N0511_R108_T32TLQ_20250113T122458.json
@@ -35,7 +35,41 @@
         "geometry": {
           "zarr_format": 3,
           "node_type": "group",
-          "attributes": {},
+          "attributes": {
+            "grid_mapping": "spatial_ref",
+            "spatial:dimensions": [
+              "y",
+              "x"
+            ],
+            "spatial:registration": "pixel",
+            "spatial:bbox": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "spatial:shape": [
+              23,
+              23
+            ],
+            "zarr_conventions": [
+              {
+                "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                "name": "spatial:",
+                "description": "Spatial coordinate information"
+              },
+              {
+                "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                "name": "proj:",
+                "description": "Coordinate reference system information for geospatial data"
+              }
+            ],
+            "proj:code": "EPSG:32632"
+          },
           "members": {
             "angle": {
               "zarr_format": 3,
@@ -160,6 +194,7 @@
               "node_type": "array",
               "attributes": {
                 "unit": "deg",
+                "grid_mapping": "spatial_ref",
                 "_FillValue": "AAAAAAAA+H8="
               },
               "shape": [
@@ -209,6 +244,7 @@
               "node_type": "array",
               "attributes": {
                 "unit": "deg",
+                "grid_mapping": "spatial_ref",
                 "_FillValue": "AAAAAAAA+H8="
               },
               "shape": [
@@ -256,10 +292,59 @@
                 "angle"
               ]
             },
+            "spatial_ref": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]",
+                "semi_major_axis": 6378137.0,
+                "semi_minor_axis": 6356752.314245179,
+                "inverse_flattening": 298.257223563,
+                "reference_ellipsoid_name": "WGS 84",
+                "longitude_of_prime_meridian": 0.0,
+                "prime_meridian_name": "Greenwich",
+                "geographic_crs_name": "WGS 84",
+                "horizontal_datum_name": "World Geodetic System 1984",
+                "projected_crs_name": "WGS 84 / UTM zone 32N",
+                "grid_mapping_name": "transverse_mercator",
+                "latitude_of_projection_origin": 0.0,
+                "longitude_of_central_meridian": 9.0,
+                "false_easting": 500000.0,
+                "false_northing": 0.0,
+                "scale_factor_at_central_meridian": 0.9996,
+                "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]"
+              },
+              "shape": [],
+              "data_type": "int64",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": []
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": 0,
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": null
+            },
             "sun_angles": {
               "zarr_format": 3,
               "node_type": "array",
               "attributes": {
+                "grid_mapping": "spatial_ref",
                 "_FillValue": "AAAAAAAA+H8="
               },
               "shape": [
@@ -314,6 +399,7 @@
               "zarr_format": 3,
               "node_type": "array",
               "attributes": {
+                "grid_mapping": "spatial_ref",
                 "_FillValue": "AAAAAAAA+H8="
               },
               "shape": [
@@ -457,7 +543,41 @@
                 "r10m": {
                   "zarr_format": 3,
                   "node_type": "group",
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:shape": [
+                      10980,
+                      10980
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "name": "spatial:",
+                        "description": "Spatial coordinate information"
+                      },
+                      {
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "name": "proj:",
+                        "description": "Coordinate reference system information for geospatial data"
+                      }
+                    ],
+                    "proj:code": "EPSG:32632"
+                  },
                   "members": {
                     "b02": {
                       "zarr_format": 3,
@@ -486,7 +606,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         10980,
@@ -557,7 +678,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         10980,
@@ -628,7 +750,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         10980,
@@ -699,7 +822,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         10980,
@@ -742,6 +866,54 @@
                         "y",
                         "x"
                       ]
+                    },
+                    "spatial_ref": {
+                      "zarr_format": 3,
+                      "node_type": "array",
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]",
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "inverse_flattening": 298.257223563,
+                        "reference_ellipsoid_name": "WGS 84",
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "geographic_crs_name": "WGS 84",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "projected_crs_name": "WGS 84 / UTM zone 32N",
+                        "grid_mapping_name": "transverse_mercator",
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": 9.0,
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]"
+                      },
+                      "shape": [],
+                      "data_type": "int64",
+                      "chunk_grid": {
+                        "name": "regular",
+                        "configuration": {
+                          "chunk_shape": []
+                        }
+                      },
+                      "chunk_key_encoding": {
+                        "name": "default",
+                        "configuration": {
+                          "separator": "/"
+                        }
+                      },
+                      "fill_value": 0,
+                      "codecs": [
+                        {
+                          "name": "bytes",
+                          "configuration": {
+                            "endian": "little"
+                          }
+                        }
+                      ],
+                      "storage_transformers": [],
+                      "dimension_names": null
                     },
                     "x": {
                       "zarr_format": 3,
@@ -820,7 +992,41 @@
                 "r20m": {
                   "zarr_format": 3,
                   "node_type": "group",
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:shape": [
+                      5490,
+                      5490
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "name": "spatial:",
+                        "description": "Spatial coordinate information"
+                      },
+                      {
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "name": "proj:",
+                        "description": "Coordinate reference system information for geospatial data"
+                      }
+                    ],
+                    "proj:code": "EPSG:32632"
+                  },
                   "members": {
                     "b05": {
                       "zarr_format": 3,
@@ -849,7 +1055,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         5490,
@@ -920,7 +1127,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         5490,
@@ -991,7 +1199,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         5490,
@@ -1062,7 +1271,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         5490,
@@ -1133,7 +1343,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         5490,
@@ -1204,7 +1415,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         5490,
@@ -1247,6 +1459,54 @@
                         "y",
                         "x"
                       ]
+                    },
+                    "spatial_ref": {
+                      "zarr_format": 3,
+                      "node_type": "array",
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]",
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "inverse_flattening": 298.257223563,
+                        "reference_ellipsoid_name": "WGS 84",
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "geographic_crs_name": "WGS 84",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "projected_crs_name": "WGS 84 / UTM zone 32N",
+                        "grid_mapping_name": "transverse_mercator",
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": 9.0,
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]"
+                      },
+                      "shape": [],
+                      "data_type": "int64",
+                      "chunk_grid": {
+                        "name": "regular",
+                        "configuration": {
+                          "chunk_shape": []
+                        }
+                      },
+                      "chunk_key_encoding": {
+                        "name": "default",
+                        "configuration": {
+                          "separator": "/"
+                        }
+                      },
+                      "fill_value": 0,
+                      "codecs": [
+                        {
+                          "name": "bytes",
+                          "configuration": {
+                            "endian": "little"
+                          }
+                        }
+                      ],
+                      "storage_transformers": [],
+                      "dimension_names": null
                     },
                     "x": {
                       "zarr_format": 3,
@@ -1325,7 +1585,41 @@
                 "r60m": {
                   "zarr_format": 3,
                   "node_type": "group",
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:shape": [
+                      1830,
+                      1830
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "name": "spatial:",
+                        "description": "Spatial coordinate information"
+                      },
+                      {
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "name": "proj:",
+                        "description": "Coordinate reference system information for geospatial data"
+                      }
+                    ],
+                    "proj:code": "EPSG:32632"
+                  },
                   "members": {
                     "b01": {
                       "zarr_format": 3,
@@ -1354,7 +1648,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         1830,
@@ -1425,7 +1720,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         1830,
@@ -1496,7 +1792,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         1830,
@@ -1539,6 +1836,54 @@
                         "y",
                         "x"
                       ]
+                    },
+                    "spatial_ref": {
+                      "zarr_format": 3,
+                      "node_type": "array",
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]",
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "inverse_flattening": 298.257223563,
+                        "reference_ellipsoid_name": "WGS 84",
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "geographic_crs_name": "WGS 84",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "projected_crs_name": "WGS 84 / UTM zone 32N",
+                        "grid_mapping_name": "transverse_mercator",
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": 9.0,
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]"
+                      },
+                      "shape": [],
+                      "data_type": "int64",
+                      "chunk_grid": {
+                        "name": "regular",
+                        "configuration": {
+                          "chunk_shape": []
+                        }
+                      },
+                      "chunk_key_encoding": {
+                        "name": "default",
+                        "configuration": {
+                          "separator": "/"
+                        }
+                      },
+                      "fill_value": 0,
+                      "codecs": [
+                        {
+                          "name": "bytes",
+                          "configuration": {
+                            "endian": "little"
+                          }
+                        }
+                      ],
+                      "storage_transformers": [],
+                      "dimension_names": null
                     },
                     "x": {
                       "zarr_format": 3,
@@ -1624,7 +1969,41 @@
                 "r60m": {
                   "zarr_format": 3,
                   "node_type": "group",
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:shape": [
+                      1830,
+                      1830
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "name": "spatial:",
+                        "description": "Spatial coordinate information"
+                      },
+                      {
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "name": "proj:",
+                        "description": "Coordinate reference system information for geospatial data"
+                      }
+                    ],
+                    "proj:code": "EPSG:32632"
+                  },
                   "members": {
                     "b00": {
                       "zarr_format": 3,
@@ -1663,7 +2042,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         1830,
@@ -1706,6 +2086,54 @@
                         "y",
                         "x"
                       ]
+                    },
+                    "spatial_ref": {
+                      "zarr_format": 3,
+                      "node_type": "array",
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]",
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "inverse_flattening": 298.257223563,
+                        "reference_ellipsoid_name": "WGS 84",
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "geographic_crs_name": "WGS 84",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "projected_crs_name": "WGS 84 / UTM zone 32N",
+                        "grid_mapping_name": "transverse_mercator",
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": 9.0,
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]"
+                      },
+                      "shape": [],
+                      "data_type": "int64",
+                      "chunk_grid": {
+                        "name": "regular",
+                        "configuration": {
+                          "chunk_shape": []
+                        }
+                      },
+                      "chunk_key_encoding": {
+                        "name": "default",
+                        "configuration": {
+                          "separator": "/"
+                        }
+                      },
+                      "fill_value": 0,
+                      "codecs": [
+                        {
+                          "name": "bytes",
+                          "configuration": {
+                            "endian": "little"
+                          }
+                        }
+                      ],
+                      "storage_transformers": [],
+                      "dimension_names": null
                     },
                     "x": {
                       "zarr_format": 3,
@@ -3966,13 +4394,6 @@
                       "configuration": {
                         "endian": "little"
                       }
-                    },
-                    {
-                      "name": "zstd",
-                      "configuration": {
-                        "level": 0,
-                        "checksum": false
-                      }
                     }
                   ],
                   "storage_transformers": [],
@@ -5135,13 +5556,6 @@
                       "configuration": {
                         "endian": "little"
                       }
-                    },
-                    {
-                      "name": "zstd",
-                      "configuration": {
-                        "level": 0,
-                        "checksum": false
-                      }
                     }
                   ],
                   "storage_transformers": [],
@@ -6075,13 +6489,6 @@
                       "name": "bytes",
                       "configuration": {
                         "endian": "little"
-                      }
-                    },
-                    {
-                      "name": "zstd",
-                      "configuration": {
-                        "level": 0,
-                        "checksum": false
                       }
                     }
                   ],
@@ -7095,13 +7502,6 @@
                       "configuration": {
                         "endian": "little"
                       }
-                    },
-                    {
-                      "name": "zstd",
-                      "configuration": {
-                        "level": 0,
-                        "checksum": false
-                      }
                     }
                   ],
                   "storage_transformers": [],
@@ -7815,13 +8215,6 @@
                       "configuration": {
                         "endian": "little"
                       }
-                    },
-                    {
-                      "name": "zstd",
-                      "configuration": {
-                        "level": 0,
-                        "checksum": false
-                      }
                     }
                   ],
                   "storage_transformers": [],
@@ -8258,13 +8651,6 @@
                       "name": "bytes",
                       "configuration": {
                         "endian": "little"
-                      }
-                    },
-                    {
-                      "name": "zstd",
-                      "configuration": {
-                        "level": 0,
-                        "checksum": false
                       }
                     }
                   ],

--- a/tests/_test_data/geozarr_examples/S2C_MSIL2A_20250811T112131_N0511_R037_T29TPF_20250811T152216.json
+++ b/tests/_test_data/geozarr_examples/S2C_MSIL2A_20250811T112131_N0511_R037_T29TPF_20250811T152216.json
@@ -35,7 +35,41 @@
         "geometry": {
           "zarr_format": 3,
           "node_type": "group",
-          "attributes": {},
+          "attributes": {
+            "grid_mapping": "spatial_ref",
+            "spatial:dimensions": [
+              "y",
+              "x"
+            ],
+            "spatial:registration": "pixel",
+            "spatial:bbox": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "spatial:shape": [
+              23,
+              23
+            ],
+            "zarr_conventions": [
+              {
+                "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                "name": "spatial:",
+                "description": "Spatial coordinate information"
+              },
+              {
+                "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                "name": "proj:",
+                "description": "Coordinate reference system information for geospatial data"
+              }
+            ],
+            "proj:code": "EPSG:32629"
+          },
           "members": {
             "angle": {
               "zarr_format": 3,
@@ -160,6 +194,7 @@
               "node_type": "array",
               "attributes": {
                 "unit": "deg",
+                "grid_mapping": "spatial_ref",
                 "_FillValue": "AAAAAAAA+H8="
               },
               "shape": [
@@ -209,6 +244,7 @@
               "node_type": "array",
               "attributes": {
                 "unit": "deg",
+                "grid_mapping": "spatial_ref",
                 "_FillValue": "AAAAAAAA+H8="
               },
               "shape": [
@@ -256,10 +292,59 @@
                 "angle"
               ]
             },
+            "spatial_ref": {
+              "zarr_format": 3,
+              "node_type": "array",
+              "attributes": {
+                "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 29N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32629\"]]",
+                "semi_major_axis": 6378137.0,
+                "semi_minor_axis": 6356752.314245179,
+                "inverse_flattening": 298.257223563,
+                "reference_ellipsoid_name": "WGS 84",
+                "longitude_of_prime_meridian": 0.0,
+                "prime_meridian_name": "Greenwich",
+                "geographic_crs_name": "WGS 84",
+                "horizontal_datum_name": "World Geodetic System 1984",
+                "projected_crs_name": "WGS 84 / UTM zone 29N",
+                "grid_mapping_name": "transverse_mercator",
+                "latitude_of_projection_origin": 0.0,
+                "longitude_of_central_meridian": -9.0,
+                "false_easting": 500000.0,
+                "false_northing": 0.0,
+                "scale_factor_at_central_meridian": 0.9996,
+                "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 29N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32629\"]]"
+              },
+              "shape": [],
+              "data_type": "int64",
+              "chunk_grid": {
+                "name": "regular",
+                "configuration": {
+                  "chunk_shape": []
+                }
+              },
+              "chunk_key_encoding": {
+                "name": "default",
+                "configuration": {
+                  "separator": "/"
+                }
+              },
+              "fill_value": 0,
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                }
+              ],
+              "storage_transformers": [],
+              "dimension_names": null
+            },
             "sun_angles": {
               "zarr_format": 3,
               "node_type": "array",
               "attributes": {
+                "grid_mapping": "spatial_ref",
                 "_FillValue": "AAAAAAAA+H8="
               },
               "shape": [
@@ -314,6 +399,7 @@
               "zarr_format": 3,
               "node_type": "array",
               "attributes": {
+                "grid_mapping": "spatial_ref",
                 "_FillValue": "AAAAAAAA+H8="
               },
               "shape": [
@@ -457,7 +543,41 @@
                 "r10m": {
                   "zarr_format": 3,
                   "node_type": "group",
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:shape": [
+                      10980,
+                      10980
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "name": "spatial:",
+                        "description": "Spatial coordinate information"
+                      },
+                      {
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "name": "proj:",
+                        "description": "Coordinate reference system information for geospatial data"
+                      }
+                    ],
+                    "proj:code": "EPSG:32629"
+                  },
                   "members": {
                     "b02": {
                       "zarr_format": 3,
@@ -486,7 +606,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         10980,
@@ -557,7 +678,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         10980,
@@ -628,7 +750,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         10980,
@@ -699,7 +822,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         10980,
@@ -742,6 +866,54 @@
                         "y",
                         "x"
                       ]
+                    },
+                    "spatial_ref": {
+                      "zarr_format": 3,
+                      "node_type": "array",
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 29N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32629\"]]",
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "inverse_flattening": 298.257223563,
+                        "reference_ellipsoid_name": "WGS 84",
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "geographic_crs_name": "WGS 84",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "projected_crs_name": "WGS 84 / UTM zone 29N",
+                        "grid_mapping_name": "transverse_mercator",
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": -9.0,
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 29N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32629\"]]"
+                      },
+                      "shape": [],
+                      "data_type": "int64",
+                      "chunk_grid": {
+                        "name": "regular",
+                        "configuration": {
+                          "chunk_shape": []
+                        }
+                      },
+                      "chunk_key_encoding": {
+                        "name": "default",
+                        "configuration": {
+                          "separator": "/"
+                        }
+                      },
+                      "fill_value": 0,
+                      "codecs": [
+                        {
+                          "name": "bytes",
+                          "configuration": {
+                            "endian": "little"
+                          }
+                        }
+                      ],
+                      "storage_transformers": [],
+                      "dimension_names": null
                     },
                     "x": {
                       "zarr_format": 3,
@@ -820,7 +992,41 @@
                 "r20m": {
                   "zarr_format": 3,
                   "node_type": "group",
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:shape": [
+                      5490,
+                      5490
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "name": "spatial:",
+                        "description": "Spatial coordinate information"
+                      },
+                      {
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "name": "proj:",
+                        "description": "Coordinate reference system information for geospatial data"
+                      }
+                    ],
+                    "proj:code": "EPSG:32629"
+                  },
                   "members": {
                     "b05": {
                       "zarr_format": 3,
@@ -849,7 +1055,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         5490,
@@ -920,7 +1127,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         5490,
@@ -991,7 +1199,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         5490,
@@ -1062,7 +1271,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         5490,
@@ -1133,7 +1343,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         5490,
@@ -1204,7 +1415,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         5490,
@@ -1247,6 +1459,54 @@
                         "y",
                         "x"
                       ]
+                    },
+                    "spatial_ref": {
+                      "zarr_format": 3,
+                      "node_type": "array",
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 29N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32629\"]]",
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "inverse_flattening": 298.257223563,
+                        "reference_ellipsoid_name": "WGS 84",
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "geographic_crs_name": "WGS 84",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "projected_crs_name": "WGS 84 / UTM zone 29N",
+                        "grid_mapping_name": "transverse_mercator",
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": -9.0,
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 29N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32629\"]]"
+                      },
+                      "shape": [],
+                      "data_type": "int64",
+                      "chunk_grid": {
+                        "name": "regular",
+                        "configuration": {
+                          "chunk_shape": []
+                        }
+                      },
+                      "chunk_key_encoding": {
+                        "name": "default",
+                        "configuration": {
+                          "separator": "/"
+                        }
+                      },
+                      "fill_value": 0,
+                      "codecs": [
+                        {
+                          "name": "bytes",
+                          "configuration": {
+                            "endian": "little"
+                          }
+                        }
+                      ],
+                      "storage_transformers": [],
+                      "dimension_names": null
                     },
                     "x": {
                       "zarr_format": 3,
@@ -1325,7 +1585,41 @@
                 "r60m": {
                   "zarr_format": 3,
                   "node_type": "group",
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:shape": [
+                      1830,
+                      1830
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "name": "spatial:",
+                        "description": "Spatial coordinate information"
+                      },
+                      {
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "name": "proj:",
+                        "description": "Coordinate reference system information for geospatial data"
+                      }
+                    ],
+                    "proj:code": "EPSG:32629"
+                  },
                   "members": {
                     "b01": {
                       "zarr_format": 3,
@@ -1354,7 +1648,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         1830,
@@ -1425,7 +1720,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         1830,
@@ -1496,7 +1792,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         1830,
@@ -1539,6 +1836,54 @@
                         "y",
                         "x"
                       ]
+                    },
+                    "spatial_ref": {
+                      "zarr_format": 3,
+                      "node_type": "array",
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 29N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32629\"]]",
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "inverse_flattening": 298.257223563,
+                        "reference_ellipsoid_name": "WGS 84",
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "geographic_crs_name": "WGS 84",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "projected_crs_name": "WGS 84 / UTM zone 29N",
+                        "grid_mapping_name": "transverse_mercator",
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": -9.0,
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 29N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32629\"]]"
+                      },
+                      "shape": [],
+                      "data_type": "int64",
+                      "chunk_grid": {
+                        "name": "regular",
+                        "configuration": {
+                          "chunk_shape": []
+                        }
+                      },
+                      "chunk_key_encoding": {
+                        "name": "default",
+                        "configuration": {
+                          "separator": "/"
+                        }
+                      },
+                      "fill_value": 0,
+                      "codecs": [
+                        {
+                          "name": "bytes",
+                          "configuration": {
+                            "endian": "little"
+                          }
+                        }
+                      ],
+                      "storage_transformers": [],
+                      "dimension_names": null
                     },
                     "x": {
                       "zarr_format": 3,
@@ -1624,7 +1969,41 @@
                 "r60m": {
                   "zarr_format": 3,
                   "node_type": "group",
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:shape": [
+                      1830,
+                      1830
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "name": "spatial:",
+                        "description": "Spatial coordinate information"
+                      },
+                      {
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "name": "proj:",
+                        "description": "Coordinate reference system information for geospatial data"
+                      }
+                    ],
+                    "proj:code": "EPSG:32629"
+                  },
                   "members": {
                     "b00": {
                       "zarr_format": 3,
@@ -1663,7 +2042,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         1830,
@@ -1706,6 +2086,54 @@
                         "y",
                         "x"
                       ]
+                    },
+                    "spatial_ref": {
+                      "zarr_format": 3,
+                      "node_type": "array",
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 29N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32629\"]]",
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "inverse_flattening": 298.257223563,
+                        "reference_ellipsoid_name": "WGS 84",
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "geographic_crs_name": "WGS 84",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "projected_crs_name": "WGS 84 / UTM zone 29N",
+                        "grid_mapping_name": "transverse_mercator",
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": -9.0,
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 29N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32629\"]]"
+                      },
+                      "shape": [],
+                      "data_type": "int64",
+                      "chunk_grid": {
+                        "name": "regular",
+                        "configuration": {
+                          "chunk_shape": []
+                        }
+                      },
+                      "chunk_key_encoding": {
+                        "name": "default",
+                        "configuration": {
+                          "separator": "/"
+                        }
+                      },
+                      "fill_value": 0,
+                      "codecs": [
+                        {
+                          "name": "bytes",
+                          "configuration": {
+                            "endian": "little"
+                          }
+                        }
+                      ],
+                      "storage_transformers": [],
+                      "dimension_names": null
                     },
                     "x": {
                       "zarr_format": 3,
@@ -1791,7 +2219,41 @@
                 "r20m": {
                   "zarr_format": 3,
                   "node_type": "group",
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:shape": [
+                      5490,
+                      5490
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "name": "spatial:",
+                        "description": "Spatial coordinate information"
+                      },
+                      {
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "name": "proj:",
+                        "description": "Coordinate reference system information for geospatial data"
+                      }
+                    ],
+                    "proj:code": "EPSG:32629"
+                  },
                   "members": {
                     "scl": {
                       "zarr_format": 3,
@@ -1818,7 +2280,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         5490,
@@ -1861,6 +2324,54 @@
                         "y",
                         "x"
                       ]
+                    },
+                    "spatial_ref": {
+                      "zarr_format": 3,
+                      "node_type": "array",
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 29N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32629\"]]",
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "inverse_flattening": 298.257223563,
+                        "reference_ellipsoid_name": "WGS 84",
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "geographic_crs_name": "WGS 84",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "projected_crs_name": "WGS 84 / UTM zone 29N",
+                        "grid_mapping_name": "transverse_mercator",
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": -9.0,
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 29N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32629\"]]"
+                      },
+                      "shape": [],
+                      "data_type": "int64",
+                      "chunk_grid": {
+                        "name": "regular",
+                        "configuration": {
+                          "chunk_shape": []
+                        }
+                      },
+                      "chunk_key_encoding": {
+                        "name": "default",
+                        "configuration": {
+                          "separator": "/"
+                        }
+                      },
+                      "fill_value": 0,
+                      "codecs": [
+                        {
+                          "name": "bytes",
+                          "configuration": {
+                            "endian": "little"
+                          }
+                        }
+                      ],
+                      "storage_transformers": [],
+                      "dimension_names": null
                     },
                     "x": {
                       "zarr_format": 3,
@@ -1939,7 +2450,41 @@
                 "r60m": {
                   "zarr_format": 3,
                   "node_type": "group",
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:shape": [
+                      1830,
+                      1830
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "name": "spatial:",
+                        "description": "Spatial coordinate information"
+                      },
+                      {
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "name": "proj:",
+                        "description": "Coordinate reference system information for geospatial data"
+                      }
+                    ],
+                    "proj:code": "EPSG:32629"
+                  },
                   "members": {
                     "scl": {
                       "zarr_format": 3,
@@ -1966,7 +2511,8 @@
                           0.0,
                           0.0,
                           1.0
-                        ]
+                        ],
+                        "grid_mapping": "spatial_ref"
                       },
                       "shape": [
                         1830,
@@ -2009,6 +2555,54 @@
                         "y",
                         "x"
                       ]
+                    },
+                    "spatial_ref": {
+                      "zarr_format": 3,
+                      "node_type": "array",
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 29N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32629\"]]",
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "inverse_flattening": 298.257223563,
+                        "reference_ellipsoid_name": "WGS 84",
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "geographic_crs_name": "WGS 84",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "projected_crs_name": "WGS 84 / UTM zone 29N",
+                        "grid_mapping_name": "transverse_mercator",
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": -9.0,
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 29N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32629\"]]"
+                      },
+                      "shape": [],
+                      "data_type": "int64",
+                      "chunk_grid": {
+                        "name": "regular",
+                        "configuration": {
+                          "chunk_shape": []
+                        }
+                      },
+                      "chunk_key_encoding": {
+                        "name": "default",
+                        "configuration": {
+                          "separator": "/"
+                        }
+                      },
+                      "fill_value": 0,
+                      "codecs": [
+                        {
+                          "name": "bytes",
+                          "configuration": {
+                            "endian": "little"
+                          }
+                        }
+                      ],
+                      "storage_transformers": [],
+                      "dimension_names": null
                     },
                     "x": {
                       "zarr_format": 3,
@@ -4269,13 +4863,6 @@
                       "configuration": {
                         "endian": "little"
                       }
-                    },
-                    {
-                      "name": "zstd",
-                      "configuration": {
-                        "level": 0,
-                        "checksum": false
-                      }
                     }
                   ],
                   "storage_transformers": [],
@@ -6349,13 +6936,6 @@
                       "name": "bytes",
                       "configuration": {
                         "endian": "little"
-                      }
-                    },
-                    {
-                      "name": "zstd",
-                      "configuration": {
-                        "level": 0,
-                        "checksum": false
                       }
                     }
                   ],
@@ -8507,13 +9087,6 @@
                       "configuration": {
                         "endian": "little"
                       }
-                    },
-                    {
-                      "name": "zstd",
-                      "configuration": {
-                        "level": 0,
-                        "checksum": false
-                      }
                     }
                   ],
                   "storage_transformers": [],
@@ -9839,13 +10412,6 @@
                       "configuration": {
                         "endian": "little"
                       }
-                    },
-                    {
-                      "name": "zstd",
-                      "configuration": {
-                        "level": 0,
-                        "checksum": false
-                      }
                     }
                   ],
                   "storage_transformers": [],
@@ -10153,13 +10719,6 @@
                       "configuration": {
                         "endian": "little"
                       }
-                    },
-                    {
-                      "name": "zstd",
-                      "configuration": {
-                        "level": 0,
-                        "checksum": false
-                      }
                     }
                   ],
                   "storage_transformers": [],
@@ -10466,13 +11025,6 @@
                       "name": "bytes",
                       "configuration": {
                         "endian": "little"
-                      }
-                    },
-                    {
-                      "name": "zstd",
-                      "configuration": {
-                        "level": 0,
-                        "checksum": false
                       }
                     }
                   ],
@@ -11082,13 +11634,6 @@
                       "name": "bytes",
                       "configuration": {
                         "endian": "little"
-                      }
-                    },
-                    {
-                      "name": "zstd",
-                      "configuration": {
-                        "level": 0,
-                        "checksum": false
                       }
                     }
                   ],
@@ -11803,13 +12348,6 @@
                       "configuration": {
                         "endian": "little"
                       }
-                    },
-                    {
-                      "name": "zstd",
-                      "configuration": {
-                        "level": 0,
-                        "checksum": false
-                      }
                     }
                   ],
                   "storage_transformers": [],
@@ -12247,13 +12785,6 @@
                       "configuration": {
                         "endian": "little"
                       }
-                    },
-                    {
-                      "name": "zstd",
-                      "configuration": {
-                        "level": 0,
-                        "checksum": false
-                      }
                     }
                   ],
                   "storage_transformers": [],
@@ -12563,13 +13094,6 @@
                       "name": "bytes",
                       "configuration": {
                         "endian": "little"
-                      }
-                    },
-                    {
-                      "name": "zstd",
-                      "configuration": {
-                        "level": 0,
-                        "checksum": false
                       }
                     }
                   ],

--- a/tests/_test_data/optimized_geozarr_examples/S2A_MSIL2A_20251008T100041_N0511_R122_T32TQM_20251008T122613.json
+++ b/tests/_test_data/optimized_geozarr_examples/S2A_MSIL2A_20251008T100041_N0511_R122_T32TQM_20251008T122613.json
@@ -423,11 +423,46 @@
               "attributes": {},
               "members": {
                 "r10m": {
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "proj:code": "EPSG:32632",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:shape": [
+                      10980,
+                      10980
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "description": "Spatial coordinate information",
+                        "name": "spatial:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4"
+                      },
+                      {
+                        "description": "Coordinate reference system information for geospatial data",
+                        "name": "proj:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f"
+                      }
+                    ]
+                  },
                   "members": {
                     "b02": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           699960.0,
@@ -499,6 +534,7 @@
                     "b03": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           699960.0,
@@ -570,6 +606,7 @@
                     "b04": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           699960.0,
@@ -641,6 +678,7 @@
                     "b08": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           699960.0,
@@ -706,6 +744,54 @@
                         10980,
                         10980
                       ],
+                      "storage_transformers": [],
+                      "zarr_format": 3
+                    },
+                    "spatial_ref": {
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]",
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "geographic_crs_name": "WGS 84",
+                        "grid_mapping_name": "transverse_mercator",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "inverse_flattening": 298.257223563,
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": 9.0,
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "projected_crs_name": "WGS 84 / UTM zone 32N",
+                        "reference_ellipsoid_name": "WGS 84",
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]"
+                      },
+                      "chunk_grid": {
+                        "configuration": {
+                          "chunk_shape": []
+                        },
+                        "name": "regular"
+                      },
+                      "chunk_key_encoding": {
+                        "configuration": {
+                          "separator": "/"
+                        },
+                        "name": "default"
+                      },
+                      "codecs": [
+                        {
+                          "configuration": {
+                            "endian": "little"
+                          },
+                          "name": "bytes"
+                        }
+                      ],
+                      "data_type": "int64",
+                      "dimension_names": null,
+                      "fill_value": 0,
+                      "node_type": "array",
+                      "shape": [],
                       "storage_transformers": [],
                       "zarr_format": 3
                     },
@@ -786,11 +872,46 @@
                   "zarr_format": 3
                 },
                 "r20m": {
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "proj:code": "EPSG:32632",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:shape": [
+                      5490,
+                      5490
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "description": "Spatial coordinate information",
+                        "name": "spatial:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4"
+                      },
+                      {
+                        "description": "Coordinate reference system information for geospatial data",
+                        "name": "proj:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f"
+                      }
+                    ]
+                  },
                   "members": {
                     "b05": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           699960.0,
@@ -862,6 +983,7 @@
                     "b06": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           699960.0,
@@ -933,6 +1055,7 @@
                     "b07": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           699960.0,
@@ -1004,6 +1127,7 @@
                     "b11": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           699960.0,
@@ -1075,6 +1199,7 @@
                     "b12": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           699960.0,
@@ -1146,6 +1271,7 @@
                     "b8a": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           699960.0,
@@ -1211,6 +1337,54 @@
                         5490,
                         5490
                       ],
+                      "storage_transformers": [],
+                      "zarr_format": 3
+                    },
+                    "spatial_ref": {
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]",
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "geographic_crs_name": "WGS 84",
+                        "grid_mapping_name": "transverse_mercator",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "inverse_flattening": 298.257223563,
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": 9.0,
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "projected_crs_name": "WGS 84 / UTM zone 32N",
+                        "reference_ellipsoid_name": "WGS 84",
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]"
+                      },
+                      "chunk_grid": {
+                        "configuration": {
+                          "chunk_shape": []
+                        },
+                        "name": "regular"
+                      },
+                      "chunk_key_encoding": {
+                        "configuration": {
+                          "separator": "/"
+                        },
+                        "name": "default"
+                      },
+                      "codecs": [
+                        {
+                          "configuration": {
+                            "endian": "little"
+                          },
+                          "name": "bytes"
+                        }
+                      ],
+                      "data_type": "int64",
+                      "dimension_names": null,
+                      "fill_value": 0,
+                      "node_type": "array",
+                      "shape": [],
                       "storage_transformers": [],
                       "zarr_format": 3
                     },
@@ -1291,11 +1465,46 @@
                   "zarr_format": 3
                 },
                 "r60m": {
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "proj:code": "EPSG:32632",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:shape": [
+                      1830,
+                      1830
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "description": "Spatial coordinate information",
+                        "name": "spatial:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4"
+                      },
+                      {
+                        "description": "Coordinate reference system information for geospatial data",
+                        "name": "proj:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f"
+                      }
+                    ]
+                  },
                   "members": {
                     "b01": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           699960.0,
@@ -1367,6 +1576,7 @@
                     "b09": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           699960.0,
@@ -1438,6 +1648,7 @@
                     "b10": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           699960.0,
@@ -1503,6 +1714,54 @@
                         1830,
                         1830
                       ],
+                      "storage_transformers": [],
+                      "zarr_format": 3
+                    },
+                    "spatial_ref": {
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]",
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "geographic_crs_name": "WGS 84",
+                        "grid_mapping_name": "transverse_mercator",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "inverse_flattening": 298.257223563,
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": 9.0,
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "projected_crs_name": "WGS 84 / UTM zone 32N",
+                        "reference_ellipsoid_name": "WGS 84",
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]"
+                      },
+                      "chunk_grid": {
+                        "configuration": {
+                          "chunk_shape": []
+                        },
+                        "name": "regular"
+                      },
+                      "chunk_key_encoding": {
+                        "configuration": {
+                          "separator": "/"
+                        },
+                        "name": "default"
+                      },
+                      "codecs": [
+                        {
+                          "configuration": {
+                            "endian": "little"
+                          },
+                          "name": "bytes"
+                        }
+                      ],
+                      "data_type": "int64",
+                      "dimension_names": null,
+                      "fill_value": 0,
+                      "node_type": "array",
+                      "shape": [],
                       "storage_transformers": [],
                       "zarr_format": 3
                     },
@@ -1590,7 +1849,41 @@
               "attributes": {},
               "members": {
                 "r60m": {
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "proj:code": "EPSG:32632",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:shape": [
+                      1830,
+                      1830
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "description": "Spatial coordinate information",
+                        "name": "spatial:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4"
+                      },
+                      {
+                        "description": "Coordinate reference system information for geospatial data",
+                        "name": "proj:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f"
+                      }
+                    ]
+                  },
                   "members": {
                     "b00": {
                       "attributes": {
@@ -1605,6 +1898,7 @@
                           "CIRRUS",
                           "SNOW_ICE"
                         ],
+                        "grid_mapping": "spatial_ref",
                         "long_name": "cloud classification mask provided in the final reference frame (ground geometry)",
                         "proj:bbox": [
                           699960.0,
@@ -1670,6 +1964,54 @@
                         1830,
                         1830
                       ],
+                      "storage_transformers": [],
+                      "zarr_format": 3
+                    },
+                    "spatial_ref": {
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]",
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "geographic_crs_name": "WGS 84",
+                        "grid_mapping_name": "transverse_mercator",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "inverse_flattening": 298.257223563,
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": 9.0,
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "projected_crs_name": "WGS 84 / UTM zone 32N",
+                        "reference_ellipsoid_name": "WGS 84",
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]"
+                      },
+                      "chunk_grid": {
+                        "configuration": {
+                          "chunk_shape": []
+                        },
+                        "name": "regular"
+                      },
+                      "chunk_key_encoding": {
+                        "configuration": {
+                          "separator": "/"
+                        },
+                        "name": "default"
+                      },
+                      "codecs": [
+                        {
+                          "configuration": {
+                            "endian": "little"
+                          },
+                          "name": "bytes"
+                        }
+                      ],
+                      "data_type": "int64",
+                      "dimension_names": null,
+                      "fill_value": 0,
+                      "node_type": "array",
+                      "shape": [],
                       "storage_transformers": [],
                       "zarr_format": 3
                     },
@@ -1757,10 +2099,45 @@
               "attributes": {},
               "members": {
                 "r20m": {
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "proj:code": "EPSG:32632",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:shape": [
+                      5490,
+                      5490
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "description": "Spatial coordinate information",
+                        "name": "spatial:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4"
+                      },
+                      {
+                        "description": "Coordinate reference system information for geospatial data",
+                        "name": "proj:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f"
+                      }
+                    ]
+                  },
                   "members": {
                     "scl": {
                       "attributes": {
+                        "grid_mapping": "spatial_ref",
                         "proj:bbox": [
                           699960.0,
                           4590240.0,
@@ -1825,6 +2202,54 @@
                         5490,
                         5490
                       ],
+                      "storage_transformers": [],
+                      "zarr_format": 3
+                    },
+                    "spatial_ref": {
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]",
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "geographic_crs_name": "WGS 84",
+                        "grid_mapping_name": "transverse_mercator",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "inverse_flattening": 298.257223563,
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": 9.0,
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "projected_crs_name": "WGS 84 / UTM zone 32N",
+                        "reference_ellipsoid_name": "WGS 84",
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]"
+                      },
+                      "chunk_grid": {
+                        "configuration": {
+                          "chunk_shape": []
+                        },
+                        "name": "regular"
+                      },
+                      "chunk_key_encoding": {
+                        "configuration": {
+                          "separator": "/"
+                        },
+                        "name": "default"
+                      },
+                      "codecs": [
+                        {
+                          "configuration": {
+                            "endian": "little"
+                          },
+                          "name": "bytes"
+                        }
+                      ],
+                      "data_type": "int64",
+                      "dimension_names": null,
+                      "fill_value": 0,
+                      "node_type": "array",
+                      "shape": [],
                       "storage_transformers": [],
                       "zarr_format": 3
                     },
@@ -1905,10 +2330,45 @@
                   "zarr_format": 3
                 },
                 "r60m": {
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "proj:code": "EPSG:32632",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:shape": [
+                      1830,
+                      1830
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "description": "Spatial coordinate information",
+                        "name": "spatial:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4"
+                      },
+                      {
+                        "description": "Coordinate reference system information for geospatial data",
+                        "name": "proj:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f"
+                      }
+                    ]
+                  },
                   "members": {
                     "scl": {
                       "attributes": {
+                        "grid_mapping": "spatial_ref",
                         "proj:bbox": [
                           699960.0,
                           4590240.0,
@@ -1973,6 +2433,54 @@
                         1830,
                         1830
                       ],
+                      "storage_transformers": [],
+                      "zarr_format": 3
+                    },
+                    "spatial_ref": {
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]",
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "geographic_crs_name": "WGS 84",
+                        "grid_mapping_name": "transverse_mercator",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "inverse_flattening": 298.257223563,
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": 9.0,
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "projected_crs_name": "WGS 84 / UTM zone 32N",
+                        "reference_ellipsoid_name": "WGS 84",
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]"
+                      },
+                      "chunk_grid": {
+                        "configuration": {
+                          "chunk_shape": []
+                        },
+                        "name": "regular"
+                      },
+                      "chunk_key_encoding": {
+                        "configuration": {
+                          "separator": "/"
+                        },
+                        "name": "default"
+                      },
+                      "codecs": [
+                        {
+                          "configuration": {
+                            "endian": "little"
+                          },
+                          "name": "bytes"
+                        }
+                      ],
+                      "data_type": "int64",
+                      "dimension_names": null,
+                      "fill_value": 0,
+                      "node_type": "array",
+                      "shape": [],
                       "storage_transformers": [],
                       "zarr_format": 3
                     },
@@ -4324,13 +4832,6 @@
                         "endian": "little"
                       },
                       "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "checksum": false,
-                        "level": 0
-                      },
-                      "name": "zstd"
                     }
                   ],
                   "data_type": "int64",
@@ -6934,13 +7435,6 @@
                         "endian": "little"
                       },
                       "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "checksum": false,
-                        "level": 0
-                      },
-                      "name": "zstd"
                     }
                   ],
                   "data_type": "int64",
@@ -9643,13 +10137,6 @@
                         "endian": "little"
                       },
                       "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "checksum": false,
-                        "level": 0
-                      },
-                      "name": "zstd"
                     }
                   ],
                   "data_type": "int64",
@@ -11251,13 +11738,6 @@
                         "endian": "little"
                       },
                       "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "checksum": false,
-                        "level": 0
-                      },
-                      "name": "zstd"
                     }
                   ],
                   "data_type": "int64",
@@ -11565,13 +12045,6 @@
                         "endian": "little"
                       },
                       "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "checksum": false,
-                        "level": 0
-                      },
-                      "name": "zstd"
                     }
                   ],
                   "data_type": "int64",
@@ -11879,13 +12352,6 @@
                         "endian": "little"
                       },
                       "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "checksum": false,
-                        "level": 0
-                      },
-                      "name": "zstd"
                     }
                   ],
                   "data_type": "int64",
@@ -12495,13 +12961,6 @@
                         "endian": "little"
                       },
                       "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "checksum": false,
-                        "level": 0
-                      },
-                      "name": "zstd"
                     }
                   ],
                   "data_type": "int64",
@@ -13215,13 +13674,6 @@
                         "endian": "little"
                       },
                       "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "checksum": false,
-                        "level": 0
-                      },
-                      "name": "zstd"
                     }
                   ],
                   "data_type": "int64",
@@ -13659,13 +14111,6 @@
                         "endian": "little"
                       },
                       "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "checksum": false,
-                        "level": 0
-                      },
-                      "name": "zstd"
                     }
                   ],
                   "data_type": "int64",
@@ -13976,13 +14421,6 @@
                         "endian": "little"
                       },
                       "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "checksum": false,
-                        "level": 0
-                      },
-                      "name": "zstd"
                     }
                   ],
                   "data_type": "int64",

--- a/tests/_test_data/optimized_geozarr_examples/S2B_MSIL1C_20250113T103309_N0511_R108_T32TLQ_20250113T122458.json
+++ b/tests/_test_data/optimized_geozarr_examples/S2B_MSIL1C_20250113T103309_N0511_R108_T32TLQ_20250113T122458.json
@@ -423,11 +423,46 @@
               "attributes": {},
               "members": {
                 "r10m": {
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "proj:code": "EPSG:32632",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:shape": [
+                      10980,
+                      10980
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "description": "Spatial coordinate information",
+                        "name": "spatial:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4"
+                      },
+                      {
+                        "description": "Coordinate reference system information for geospatial data",
+                        "name": "proj:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f"
+                      }
+                    ]
+                  },
                   "members": {
                     "b02": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           300000.0,
@@ -499,6 +534,7 @@
                     "b03": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           300000.0,
@@ -570,6 +606,7 @@
                     "b04": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           300000.0,
@@ -641,6 +678,7 @@
                     "b08": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           300000.0,
@@ -706,6 +744,54 @@
                         10980,
                         10980
                       ],
+                      "storage_transformers": [],
+                      "zarr_format": 3
+                    },
+                    "spatial_ref": {
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]",
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "geographic_crs_name": "WGS 84",
+                        "grid_mapping_name": "transverse_mercator",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "inverse_flattening": 298.257223563,
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": 9.0,
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "projected_crs_name": "WGS 84 / UTM zone 32N",
+                        "reference_ellipsoid_name": "WGS 84",
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]"
+                      },
+                      "chunk_grid": {
+                        "configuration": {
+                          "chunk_shape": []
+                        },
+                        "name": "regular"
+                      },
+                      "chunk_key_encoding": {
+                        "configuration": {
+                          "separator": "/"
+                        },
+                        "name": "default"
+                      },
+                      "codecs": [
+                        {
+                          "configuration": {
+                            "endian": "little"
+                          },
+                          "name": "bytes"
+                        }
+                      ],
+                      "data_type": "int64",
+                      "dimension_names": null,
+                      "fill_value": 0,
+                      "node_type": "array",
+                      "shape": [],
                       "storage_transformers": [],
                       "zarr_format": 3
                     },
@@ -786,11 +872,46 @@
                   "zarr_format": 3
                 },
                 "r20m": {
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "proj:code": "EPSG:32632",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:shape": [
+                      5490,
+                      5490
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "description": "Spatial coordinate information",
+                        "name": "spatial:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4"
+                      },
+                      {
+                        "description": "Coordinate reference system information for geospatial data",
+                        "name": "proj:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f"
+                      }
+                    ]
+                  },
                   "members": {
                     "b05": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           300000.0,
@@ -862,6 +983,7 @@
                     "b06": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           300000.0,
@@ -933,6 +1055,7 @@
                     "b07": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           300000.0,
@@ -1004,6 +1127,7 @@
                     "b11": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           300000.0,
@@ -1075,6 +1199,7 @@
                     "b12": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           300000.0,
@@ -1146,6 +1271,7 @@
                     "b8a": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           300000.0,
@@ -1211,6 +1337,54 @@
                         5490,
                         5490
                       ],
+                      "storage_transformers": [],
+                      "zarr_format": 3
+                    },
+                    "spatial_ref": {
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]",
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "geographic_crs_name": "WGS 84",
+                        "grid_mapping_name": "transverse_mercator",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "inverse_flattening": 298.257223563,
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": 9.0,
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "projected_crs_name": "WGS 84 / UTM zone 32N",
+                        "reference_ellipsoid_name": "WGS 84",
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]"
+                      },
+                      "chunk_grid": {
+                        "configuration": {
+                          "chunk_shape": []
+                        },
+                        "name": "regular"
+                      },
+                      "chunk_key_encoding": {
+                        "configuration": {
+                          "separator": "/"
+                        },
+                        "name": "default"
+                      },
+                      "codecs": [
+                        {
+                          "configuration": {
+                            "endian": "little"
+                          },
+                          "name": "bytes"
+                        }
+                      ],
+                      "data_type": "int64",
+                      "dimension_names": null,
+                      "fill_value": 0,
+                      "node_type": "array",
+                      "shape": [],
                       "storage_transformers": [],
                       "zarr_format": 3
                     },
@@ -1291,11 +1465,46 @@
                   "zarr_format": 3
                 },
                 "r60m": {
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "proj:code": "EPSG:32632",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:shape": [
+                      1830,
+                      1830
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "description": "Spatial coordinate information",
+                        "name": "spatial:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4"
+                      },
+                      {
+                        "description": "Coordinate reference system information for geospatial data",
+                        "name": "proj:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f"
+                      }
+                    ]
+                  },
                   "members": {
                     "b01": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           300000.0,
@@ -1367,6 +1576,7 @@
                     "b09": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           300000.0,
@@ -1438,6 +1648,7 @@
                     "b10": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           300000.0,
@@ -1503,6 +1714,54 @@
                         1830,
                         1830
                       ],
+                      "storage_transformers": [],
+                      "zarr_format": 3
+                    },
+                    "spatial_ref": {
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]",
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "geographic_crs_name": "WGS 84",
+                        "grid_mapping_name": "transverse_mercator",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "inverse_flattening": 298.257223563,
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": 9.0,
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "projected_crs_name": "WGS 84 / UTM zone 32N",
+                        "reference_ellipsoid_name": "WGS 84",
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]"
+                      },
+                      "chunk_grid": {
+                        "configuration": {
+                          "chunk_shape": []
+                        },
+                        "name": "regular"
+                      },
+                      "chunk_key_encoding": {
+                        "configuration": {
+                          "separator": "/"
+                        },
+                        "name": "default"
+                      },
+                      "codecs": [
+                        {
+                          "configuration": {
+                            "endian": "little"
+                          },
+                          "name": "bytes"
+                        }
+                      ],
+                      "data_type": "int64",
+                      "dimension_names": null,
+                      "fill_value": 0,
+                      "node_type": "array",
+                      "shape": [],
                       "storage_transformers": [],
                       "zarr_format": 3
                     },
@@ -1590,7 +1849,41 @@
               "attributes": {},
               "members": {
                 "r60m": {
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "proj:code": "EPSG:32632",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:shape": [
+                      1830,
+                      1830
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "description": "Spatial coordinate information",
+                        "name": "spatial:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4"
+                      },
+                      {
+                        "description": "Coordinate reference system information for geospatial data",
+                        "name": "proj:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f"
+                      }
+                    ]
+                  },
                   "members": {
                     "b00": {
                       "attributes": {
@@ -1605,6 +1898,7 @@
                           "CIRRUS",
                           "SNOW_ICE"
                         ],
+                        "grid_mapping": "spatial_ref",
                         "long_name": "cloud classification mask provided in the final reference frame (ground geometry)",
                         "proj:bbox": [
                           300000.0,
@@ -1670,6 +1964,54 @@
                         1830,
                         1830
                       ],
+                      "storage_transformers": [],
+                      "zarr_format": 3
+                    },
+                    "spatial_ref": {
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]",
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "geographic_crs_name": "WGS 84",
+                        "grid_mapping_name": "transverse_mercator",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "inverse_flattening": 298.257223563,
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": 9.0,
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "projected_crs_name": "WGS 84 / UTM zone 32N",
+                        "reference_ellipsoid_name": "WGS 84",
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 32N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32632\"]]"
+                      },
+                      "chunk_grid": {
+                        "configuration": {
+                          "chunk_shape": []
+                        },
+                        "name": "regular"
+                      },
+                      "chunk_key_encoding": {
+                        "configuration": {
+                          "separator": "/"
+                        },
+                        "name": "default"
+                      },
+                      "codecs": [
+                        {
+                          "configuration": {
+                            "endian": "little"
+                          },
+                          "name": "bytes"
+                        }
+                      ],
+                      "data_type": "int64",
+                      "dimension_names": null,
+                      "fill_value": 0,
+                      "node_type": "array",
+                      "shape": [],
                       "storage_transformers": [],
                       "zarr_format": 3
                     },
@@ -4021,13 +4363,6 @@
                         "endian": "little"
                       },
                       "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "checksum": false,
-                        "level": 0
-                      },
-                      "name": "zstd"
                     }
                   ],
                   "data_type": "int64",
@@ -5443,13 +5778,6 @@
                         "endian": "little"
                       },
                       "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "checksum": false,
-                        "level": 0
-                      },
-                      "name": "zstd"
                     }
                   ],
                   "data_type": "int64",
@@ -6568,13 +6896,6 @@
                         "endian": "little"
                       },
                       "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "checksum": false,
-                        "level": 0
-                      },
-                      "name": "zstd"
                     }
                   ],
                   "data_type": "int64",
@@ -7679,13 +8000,6 @@
                         "endian": "little"
                       },
                       "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "checksum": false,
-                        "level": 0
-                      },
-                      "name": "zstd"
                     }
                   ],
                   "data_type": "int64",
@@ -8399,13 +8713,6 @@
                         "endian": "little"
                       },
                       "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "checksum": false,
-                        "level": 0
-                      },
-                      "name": "zstd"
                     }
                   ],
                   "data_type": "int64",
@@ -8843,13 +9150,6 @@
                         "endian": "little"
                       },
                       "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "checksum": false,
-                        "level": 0
-                      },
-                      "name": "zstd"
                     }
                   ],
                   "data_type": "int64",

--- a/tests/_test_data/optimized_geozarr_examples/S2C_MSIL2A_20250811T112131_N0511_R037_T29TPF_20250811T152216.json
+++ b/tests/_test_data/optimized_geozarr_examples/S2C_MSIL2A_20250811T112131_N0511_R037_T29TPF_20250811T152216.json
@@ -423,11 +423,46 @@
               "attributes": {},
               "members": {
                 "r10m": {
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "proj:code": "EPSG:32629",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:shape": [
+                      10980,
+                      10980
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "description": "Spatial coordinate information",
+                        "name": "spatial:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4"
+                      },
+                      {
+                        "description": "Coordinate reference system information for geospatial data",
+                        "name": "proj:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f"
+                      }
+                    ]
+                  },
                   "members": {
                     "b02": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           600000.0,
@@ -499,6 +534,7 @@
                     "b03": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           600000.0,
@@ -570,6 +606,7 @@
                     "b04": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           600000.0,
@@ -641,6 +678,7 @@
                     "b08": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           600000.0,
@@ -706,6 +744,54 @@
                         10980,
                         10980
                       ],
+                      "storage_transformers": [],
+                      "zarr_format": 3
+                    },
+                    "spatial_ref": {
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 29N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32629\"]]",
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "geographic_crs_name": "WGS 84",
+                        "grid_mapping_name": "transverse_mercator",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "inverse_flattening": 298.257223563,
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": -9.0,
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "projected_crs_name": "WGS 84 / UTM zone 29N",
+                        "reference_ellipsoid_name": "WGS 84",
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 29N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32629\"]]"
+                      },
+                      "chunk_grid": {
+                        "configuration": {
+                          "chunk_shape": []
+                        },
+                        "name": "regular"
+                      },
+                      "chunk_key_encoding": {
+                        "configuration": {
+                          "separator": "/"
+                        },
+                        "name": "default"
+                      },
+                      "codecs": [
+                        {
+                          "configuration": {
+                            "endian": "little"
+                          },
+                          "name": "bytes"
+                        }
+                      ],
+                      "data_type": "int64",
+                      "dimension_names": null,
+                      "fill_value": 0,
+                      "node_type": "array",
+                      "shape": [],
                       "storage_transformers": [],
                       "zarr_format": 3
                     },
@@ -786,11 +872,46 @@
                   "zarr_format": 3
                 },
                 "r20m": {
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "proj:code": "EPSG:32629",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:shape": [
+                      5490,
+                      5490
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "description": "Spatial coordinate information",
+                        "name": "spatial:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4"
+                      },
+                      {
+                        "description": "Coordinate reference system information for geospatial data",
+                        "name": "proj:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f"
+                      }
+                    ]
+                  },
                   "members": {
                     "b05": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           600000.0,
@@ -862,6 +983,7 @@
                     "b06": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           600000.0,
@@ -933,6 +1055,7 @@
                     "b07": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           600000.0,
@@ -1004,6 +1127,7 @@
                     "b11": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           600000.0,
@@ -1075,6 +1199,7 @@
                     "b12": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           600000.0,
@@ -1146,6 +1271,7 @@
                     "b8a": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           600000.0,
@@ -1211,6 +1337,54 @@
                         5490,
                         5490
                       ],
+                      "storage_transformers": [],
+                      "zarr_format": 3
+                    },
+                    "spatial_ref": {
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 29N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32629\"]]",
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "geographic_crs_name": "WGS 84",
+                        "grid_mapping_name": "transverse_mercator",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "inverse_flattening": 298.257223563,
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": -9.0,
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "projected_crs_name": "WGS 84 / UTM zone 29N",
+                        "reference_ellipsoid_name": "WGS 84",
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 29N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32629\"]]"
+                      },
+                      "chunk_grid": {
+                        "configuration": {
+                          "chunk_shape": []
+                        },
+                        "name": "regular"
+                      },
+                      "chunk_key_encoding": {
+                        "configuration": {
+                          "separator": "/"
+                        },
+                        "name": "default"
+                      },
+                      "codecs": [
+                        {
+                          "configuration": {
+                            "endian": "little"
+                          },
+                          "name": "bytes"
+                        }
+                      ],
+                      "data_type": "int64",
+                      "dimension_names": null,
+                      "fill_value": 0,
+                      "node_type": "array",
+                      "shape": [],
                       "storage_transformers": [],
                       "zarr_format": 3
                     },
@@ -1291,11 +1465,46 @@
                   "zarr_format": 3
                 },
                 "r60m": {
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "proj:code": "EPSG:32629",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:shape": [
+                      1830,
+                      1830
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "description": "Spatial coordinate information",
+                        "name": "spatial:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4"
+                      },
+                      {
+                        "description": "Coordinate reference system information for geospatial data",
+                        "name": "proj:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f"
+                      }
+                    ]
+                  },
                   "members": {
                     "b01": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           600000.0,
@@ -1367,6 +1576,7 @@
                     "b09": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           600000.0,
@@ -1438,6 +1648,7 @@
                     "b10": {
                       "attributes": {
                         "dtype": "<u1",
+                        "grid_mapping": "spatial_ref",
                         "long_name": "detector footprint mask provided in the final reference frame (ground geometry). 0 = no detector, 1-12 = detector 1-12",
                         "proj:bbox": [
                           600000.0,
@@ -1503,6 +1714,54 @@
                         1830,
                         1830
                       ],
+                      "storage_transformers": [],
+                      "zarr_format": 3
+                    },
+                    "spatial_ref": {
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 29N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32629\"]]",
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "geographic_crs_name": "WGS 84",
+                        "grid_mapping_name": "transverse_mercator",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "inverse_flattening": 298.257223563,
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": -9.0,
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "projected_crs_name": "WGS 84 / UTM zone 29N",
+                        "reference_ellipsoid_name": "WGS 84",
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 29N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32629\"]]"
+                      },
+                      "chunk_grid": {
+                        "configuration": {
+                          "chunk_shape": []
+                        },
+                        "name": "regular"
+                      },
+                      "chunk_key_encoding": {
+                        "configuration": {
+                          "separator": "/"
+                        },
+                        "name": "default"
+                      },
+                      "codecs": [
+                        {
+                          "configuration": {
+                            "endian": "little"
+                          },
+                          "name": "bytes"
+                        }
+                      ],
+                      "data_type": "int64",
+                      "dimension_names": null,
+                      "fill_value": 0,
+                      "node_type": "array",
+                      "shape": [],
                       "storage_transformers": [],
                       "zarr_format": 3
                     },
@@ -1590,7 +1849,41 @@
               "attributes": {},
               "members": {
                 "r60m": {
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "proj:code": "EPSG:32629",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:shape": [
+                      1830,
+                      1830
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "description": "Spatial coordinate information",
+                        "name": "spatial:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4"
+                      },
+                      {
+                        "description": "Coordinate reference system information for geospatial data",
+                        "name": "proj:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f"
+                      }
+                    ]
+                  },
                   "members": {
                     "b00": {
                       "attributes": {
@@ -1605,6 +1898,7 @@
                           "CIRRUS",
                           "SNOW_ICE"
                         ],
+                        "grid_mapping": "spatial_ref",
                         "long_name": "cloud classification mask provided in the final reference frame (ground geometry)",
                         "proj:bbox": [
                           600000.0,
@@ -1670,6 +1964,54 @@
                         1830,
                         1830
                       ],
+                      "storage_transformers": [],
+                      "zarr_format": 3
+                    },
+                    "spatial_ref": {
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 29N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32629\"]]",
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "geographic_crs_name": "WGS 84",
+                        "grid_mapping_name": "transverse_mercator",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "inverse_flattening": 298.257223563,
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": -9.0,
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "projected_crs_name": "WGS 84 / UTM zone 29N",
+                        "reference_ellipsoid_name": "WGS 84",
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 29N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32629\"]]"
+                      },
+                      "chunk_grid": {
+                        "configuration": {
+                          "chunk_shape": []
+                        },
+                        "name": "regular"
+                      },
+                      "chunk_key_encoding": {
+                        "configuration": {
+                          "separator": "/"
+                        },
+                        "name": "default"
+                      },
+                      "codecs": [
+                        {
+                          "configuration": {
+                            "endian": "little"
+                          },
+                          "name": "bytes"
+                        }
+                      ],
+                      "data_type": "int64",
+                      "dimension_names": null,
+                      "fill_value": 0,
+                      "node_type": "array",
+                      "shape": [],
                       "storage_transformers": [],
                       "zarr_format": 3
                     },
@@ -1757,10 +2099,45 @@
               "attributes": {},
               "members": {
                 "r20m": {
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "proj:code": "EPSG:32629",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:shape": [
+                      5490,
+                      5490
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "description": "Spatial coordinate information",
+                        "name": "spatial:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4"
+                      },
+                      {
+                        "description": "Coordinate reference system information for geospatial data",
+                        "name": "proj:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f"
+                      }
+                    ]
+                  },
                   "members": {
                     "scl": {
                       "attributes": {
+                        "grid_mapping": "spatial_ref",
                         "proj:bbox": [
                           600000.0,
                           4490220.0,
@@ -1825,6 +2202,54 @@
                         5490,
                         5490
                       ],
+                      "storage_transformers": [],
+                      "zarr_format": 3
+                    },
+                    "spatial_ref": {
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 29N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32629\"]]",
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "geographic_crs_name": "WGS 84",
+                        "grid_mapping_name": "transverse_mercator",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "inverse_flattening": 298.257223563,
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": -9.0,
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "projected_crs_name": "WGS 84 / UTM zone 29N",
+                        "reference_ellipsoid_name": "WGS 84",
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 29N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32629\"]]"
+                      },
+                      "chunk_grid": {
+                        "configuration": {
+                          "chunk_shape": []
+                        },
+                        "name": "regular"
+                      },
+                      "chunk_key_encoding": {
+                        "configuration": {
+                          "separator": "/"
+                        },
+                        "name": "default"
+                      },
+                      "codecs": [
+                        {
+                          "configuration": {
+                            "endian": "little"
+                          },
+                          "name": "bytes"
+                        }
+                      ],
+                      "data_type": "int64",
+                      "dimension_names": null,
+                      "fill_value": 0,
+                      "node_type": "array",
+                      "shape": [],
                       "storage_transformers": [],
                       "zarr_format": 3
                     },
@@ -1905,10 +2330,45 @@
                   "zarr_format": 3
                 },
                 "r60m": {
-                  "attributes": {},
+                  "attributes": {
+                    "grid_mapping": "spatial_ref",
+                    "proj:code": "EPSG:32629",
+                    "spatial:bbox": [
+                      0.0,
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "spatial:dimensions": [
+                      "y",
+                      "x"
+                    ],
+                    "spatial:registration": "pixel",
+                    "spatial:shape": [
+                      1830,
+                      1830
+                    ],
+                    "zarr_conventions": [
+                      {
+                        "description": "Spatial coordinate information",
+                        "name": "spatial:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/54d81b7ced0376e63ee10f34db31db7d08dcc28d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/spatial/blob/54d81b7ced0376e63ee10f34db31db7d08dcc28d/README.md",
+                        "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4"
+                      },
+                      {
+                        "description": "Coordinate reference system information for geospatial data",
+                        "name": "proj:",
+                        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/proj/5ca5b2f92e5c7245f957d9128b289ee535f0720d/schema.json",
+                        "spec_url": "https://github.com/zarr-conventions/proj/blob/5ca5b2f92e5c7245f957d9128b289ee535f0720d/README.md",
+                        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f"
+                      }
+                    ]
+                  },
                   "members": {
                     "scl": {
                       "attributes": {
+                        "grid_mapping": "spatial_ref",
                         "proj:bbox": [
                           600000.0,
                           4490220.0,
@@ -1973,6 +2433,54 @@
                         1830,
                         1830
                       ],
+                      "storage_transformers": [],
+                      "zarr_format": 3
+                    },
+                    "spatial_ref": {
+                      "attributes": {
+                        "crs_wkt": "PROJCS[\"WGS 84 / UTM zone 29N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32629\"]]",
+                        "false_easting": 500000.0,
+                        "false_northing": 0.0,
+                        "geographic_crs_name": "WGS 84",
+                        "grid_mapping_name": "transverse_mercator",
+                        "horizontal_datum_name": "World Geodetic System 1984",
+                        "inverse_flattening": 298.257223563,
+                        "latitude_of_projection_origin": 0.0,
+                        "longitude_of_central_meridian": -9.0,
+                        "longitude_of_prime_meridian": 0.0,
+                        "prime_meridian_name": "Greenwich",
+                        "projected_crs_name": "WGS 84 / UTM zone 29N",
+                        "reference_ellipsoid_name": "WGS 84",
+                        "scale_factor_at_central_meridian": 0.9996,
+                        "semi_major_axis": 6378137.0,
+                        "semi_minor_axis": 6356752.314245179,
+                        "spatial_ref": "PROJCS[\"WGS 84 / UTM zone 29N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32629\"]]"
+                      },
+                      "chunk_grid": {
+                        "configuration": {
+                          "chunk_shape": []
+                        },
+                        "name": "regular"
+                      },
+                      "chunk_key_encoding": {
+                        "configuration": {
+                          "separator": "/"
+                        },
+                        "name": "default"
+                      },
+                      "codecs": [
+                        {
+                          "configuration": {
+                            "endian": "little"
+                          },
+                          "name": "bytes"
+                        }
+                      ],
+                      "data_type": "int64",
+                      "dimension_names": null,
+                      "fill_value": 0,
+                      "node_type": "array",
+                      "shape": [],
                       "storage_transformers": [],
                       "zarr_format": 3
                     },
@@ -4324,13 +4832,6 @@
                         "endian": "little"
                       },
                       "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "checksum": false,
-                        "level": 0
-                      },
-                      "name": "zstd"
                     }
                   ],
                   "data_type": "int64",
@@ -6934,13 +7435,6 @@
                         "endian": "little"
                       },
                       "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "checksum": false,
-                        "level": 0
-                      },
-                      "name": "zstd"
                     }
                   ],
                   "data_type": "int64",
@@ -9643,13 +10137,6 @@
                         "endian": "little"
                       },
                       "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "checksum": false,
-                        "level": 0
-                      },
-                      "name": "zstd"
                     }
                   ],
                   "data_type": "int64",
@@ -11251,13 +11738,6 @@
                         "endian": "little"
                       },
                       "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "checksum": false,
-                        "level": 0
-                      },
-                      "name": "zstd"
                     }
                   ],
                   "data_type": "int64",
@@ -11565,13 +12045,6 @@
                         "endian": "little"
                       },
                       "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "checksum": false,
-                        "level": 0
-                      },
-                      "name": "zstd"
                     }
                   ],
                   "data_type": "int64",
@@ -11879,13 +12352,6 @@
                         "endian": "little"
                       },
                       "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "checksum": false,
-                        "level": 0
-                      },
-                      "name": "zstd"
                     }
                   ],
                   "data_type": "int64",
@@ -12495,13 +12961,6 @@
                         "endian": "little"
                       },
                       "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "checksum": false,
-                        "level": 0
-                      },
-                      "name": "zstd"
                     }
                   ],
                   "data_type": "int64",
@@ -13215,13 +13674,6 @@
                         "endian": "little"
                       },
                       "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "checksum": false,
-                        "level": 0
-                      },
-                      "name": "zstd"
                     }
                   ],
                   "data_type": "int64",
@@ -13659,13 +14111,6 @@
                         "endian": "little"
                       },
                       "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "checksum": false,
-                        "level": 0
-                      },
-                      "name": "zstd"
                     }
                   ],
                   "data_type": "int64",
@@ -13976,13 +14421,6 @@
                         "endian": "little"
                       },
                       "name": "bytes"
-                    },
-                    {
-                      "configuration": {
-                        "checksum": false,
-                        "level": 0
-                      },
-                      "name": "zstd"
                     }
                   ],
                   "data_type": "int64",

--- a/tests/test_s2_multiscale.py
+++ b/tests/test_s2_multiscale.py
@@ -100,13 +100,14 @@ def test_add_multiscales_metadata_prefers_coordinate_transform_for_inconsistent_
     assert isinstance(derived_level, Mapping)
     transform = derived_level["spatial:transform"]
     assert isinstance(transform, Sequence)
+    # Origin is the outer pixel edge, half of the 120 m pixel outside the first centre.
     assert tuple(transform) == (
         120.0,
         0.0,
-        600030.0,
+        599970.0,
         0.0,
         -120.0,
-        4899990.0,
+        4900050.0,
     )
 
 

--- a/tests/test_s2_multiscale_geo_metadata.py
+++ b/tests/test_s2_multiscale_geo_metadata.py
@@ -16,6 +16,8 @@ from zarr_cm import spatial as spatial_cm
 
 from eopf_geozarr.s2_optimization.s2_multiscale import (
     create_measurements_encoding,
+    create_original_encoding,
+    needs_geo_metadata,
     stream_write_dataset,
     write_geo_metadata,
 )
@@ -265,7 +267,9 @@ class TestWriteGeoMetadata:
         with patch.object(ds.rio, "transform", stale_transform):
             write_geo_metadata(ds)
 
-        assert ds.attrs["spatial:transform"] == [120.0, 0.0, 600030.0, 0.0, -120.0, 4899990.0]
+        # Origin is the outer pixel edge: half of the 120 m pixel outside the first centre.
+        assert ds.attrs["spatial:transform"] == [120.0, 0.0, 599970.0, 0.0, -120.0, 4900050.0]
+        assert ds.attrs["spatial:bbox"] == [599970.0, 4899690.0, 600330.0, 4900050.0]
 
 
 class TestWriteGeoMetadataEdgeCases:
@@ -416,3 +420,115 @@ class TestWriteGeoMetadataEdgeCases:
 
         # Verify zarr_conventions was not added since no CRS was available
         assert "zarr_conventions" not in sample_dataset_no_crs.attrs
+
+
+class TestNeedsGeoMetadata:
+    """Test which groups are stamped with geographic metadata."""
+
+    @staticmethod
+    def _gridded(dims: tuple[str, str]) -> xr.Dataset:
+        """A tiny 2-D dataset on the named dimensions."""
+        y_dim, x_dim = dims
+        return xr.Dataset(
+            {"var": ([y_dim, x_dim], np.zeros((4, 4)))},
+            coords={y_dim: (([y_dim]), np.arange(4.0)), x_dim: (([x_dim]), np.arange(4.0))},
+        )
+
+    def test_projected_grid_needs_geo_metadata(self) -> None:
+        """A group gridded on x/y is in the product CRS."""
+        assert needs_geo_metadata(self._gridded(("y", "x")))
+
+    def test_lat_lon_grid_is_skipped(self) -> None:
+        """Meteorology is on latitude/longitude and must not get the product CRS."""
+        assert not needs_geo_metadata(self._gridded(("latitude", "longitude")))
+
+    def test_non_raster_group_is_skipped(self) -> None:
+        """A group with no raster dims at all is skipped."""
+        assert not needs_geo_metadata(xr.Dataset({"var": (["angle"], np.zeros(3))}))
+
+    def test_extra_dims_still_need_geo_metadata(self) -> None:
+        """Angle grids are multi-dimensional but still live on the x/y grid."""
+        ds = xr.Dataset(
+            {"sun_angles": (["angle", "y", "x"], np.zeros((2, 4, 4)))},
+            coords={"y": np.arange(4.0), "x": np.arange(4.0)},
+        )
+        assert needs_geo_metadata(ds)
+
+    def test_classification_mask_is_readable_after_write(self, tmp_path: Path) -> None:
+        """A written SCL group carries the CRS, grid_mapping and spatial_ref a reader needs."""
+        # A 20 m grid, so the expected pixel edges below are exact.
+        coords = {
+            "x": (["x"], 499980.0 + np.arange(100) * 20.0),
+            "y": (["y"], 5800020.0 - np.arange(100) * 20.0),
+        }
+        data_vars = {"scl": (["y", "x"], np.zeros((100, 100), dtype="uint8"))}
+
+        ds = xr.Dataset(data_vars, coords=coords)
+        ds = ds.rio.write_crs("EPSG:32632")
+
+        # Masks are not a measurement group, so the converter builds their encoding here.
+        encoding = create_original_encoding(ds)
+
+        dataset_path = "/conditions/mask/l2a_classification/r20m"
+        stream_write_dataset(
+            ds,
+            path=dataset_path,
+            group=zarr.create_group(tmp_path),
+            encoding=encoding,
+            enable_sharding=True,
+        )
+
+        written_ds = xr.open_dataset(
+            tmp_path, engine="zarr", chunks={}, decode_coords="all", group=dataset_path
+        )
+
+        assert written_ds.rio.crs is not None
+        assert written_ds.rio.crs.to_epsg() == 32632
+        assert "spatial_ref" in written_ds.coords
+        assert "proj:code" in written_ds.attrs or "proj:wkt2" in written_ds.attrs
+
+        # Directed values, not just key presence: the footprint covers the pixel
+        # edges and agrees with the transform origin.
+        assert written_ds.attrs["spatial:bbox"] == [499970.0, 5798030.0, 501970.0, 5800030.0]
+        assert written_ds.attrs["spatial:transform"] == [
+            20.0,
+            0.0,
+            499970.0,
+            0.0,
+            -20.0,
+            5800030.0,
+        ]
+        assert written_ds.attrs["spatial:shape"] == [100, 100]
+
+        # `decode_coords="all"` consumes the attribute on read, so check the store:
+        # a reader that opens the group as a DataTree needs it there.
+        written_group = zarr.open_group(tmp_path, path=dataset_path, mode="r")
+        assert written_group["scl"].attrs["grid_mapping"] == "spatial_ref"
+
+    def test_lat_lon_group_is_left_alone(self, tmp_path: Path) -> None:
+        """A meteorology group on a lat/lon grid must not be stamped with the product CRS."""
+        coords = {
+            "longitude": (["longitude"], np.linspace(10.0, 11.0, 8)),
+            "latitude": (["latitude"], np.linspace(45.0, 46.0, 8)),
+        }
+        data_vars = {"aod550": (["latitude", "longitude"], np.zeros((8, 8)))}
+
+        ds = xr.Dataset(data_vars, coords=coords)
+        encoding = create_original_encoding(ds)
+
+        dataset_path = "/conditions/meteorology/cams"
+        stream_write_dataset(
+            ds,
+            path=dataset_path,
+            group=zarr.create_group(tmp_path),
+            encoding=encoding,
+            enable_sharding=True,
+        )
+
+        written_ds = xr.open_dataset(
+            tmp_path, engine="zarr", chunks={}, decode_coords="all", group=dataset_path
+        )
+
+        assert written_ds.rio.crs is None
+        assert "spatial_ref" not in written_ds.coords
+        assert not [k for k in written_ds.attrs if k.startswith(("spatial:", "proj:"))]


### PR DESCRIPTION
`conditions/mask/l2a_classification` had no spatial/proj attrs, no `spatial_ref` and no `grid_mapping`, so a GeoZarr reader could not open it — the cause of the SCL_20m failure in EOPF-Explorer/titiler-eopf#163. Geo metadata is now written for any group gridded on x/y rather than for a hardcoded list of paths. Verified by opening a freshly converted store with titiler's `GeoZarrReader`: the group lists `/r20m:scl` and `/r60m:scl`, where before it raised `ValueError: not enough values to unpack`.

For reviewers: this also changes `spatial:bbox` and `spatial:transform` for **every** geo-stamped group — they were computed from pixel centres and are now pixel edges, a half-pixel shift that propagates to the store-root footprint. Two tests that encoded the old values were updated, and the three structure fixtures were regenerated (the only new nodes are `spatial_ref` under `conditions/mask/**`). The pixel-centre premise behind that outset is verified against a shipped store (`S2C_MSIL2A_20260427T101021_N0512_R022_T33UWT_20260427T151616_converted.zarr`): every geo-stamped group at every level implies the same left edge `499980.00` — `measurements/reflectance/r10m` `x[0]=499985`, r60m `500010`, r720m `500340`, `conditions/mask/l2a_classification/r20m` `499990`. The half-pixel shift is therefore not a convention change: it makes `spatial:bbox`/`spatial:transform` agree with coordinates that were already centres. Happy to split that half out if you would rather ship the SCL fix alone.

A second commit here widens the CF standard-name-table `except` to `(OSError, HTTPException)` and warns when validation degrades to off — the same block, verbatim, as the `s1-tiling` branch (#216), which rewrote this `except` from the other direction. Identical text on both sides means whichever of the two merges second merges cleanly; simulated both orders locally and they produce the same tree.

## Author attestation

- [x] I am a human, these are my changes, and I have reviewed and understood every change and can explain why each is correct.

AI-assisted: implementation and tests drafted with Claude Code, then reviewed against a converted store and titiler's reader; every behavioural claim above was checked by running it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



